### PR TITLE
Add Account Settings page and update input box styling.

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -32,6 +32,7 @@
   "password_reset_failed": "E-Mail zum Zurücksetzen des Passworts konnte nicht gesendet werden. Bitte erneut versuchen.",
 
   "set_new_password": "Neues Passwort Festlegen",
+  "current_password": "Aktuelles Passwort",
   "new_password": "Neues Passwort",
   "new_password_repeat": "Neues Passwort wiederholen",
   "confirm": "Bestätigen",
@@ -49,8 +50,10 @@
   "email_invalid": "E-Mail ist ungültig",
   "password_required": "Passwort ist erforderlich",
   "password_repeat_required": "Neues Passwort wiederholen ist erforderlich",
+  "current_password_incorrect": "Aktuelles Passwort falsch",
 
-  "edit_profile": "Profil bearbeiten",
+  "account_settings": "Kontoeinstellungen",
+  "preferred_language": "Bevorzugte Sprache",
 
   "search": "Suchen",
   "recipe_not_found": "Rezept nicht gefunden.",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -37,6 +37,7 @@
   "new_password_repeat": "Neues Passwort wiederholen",
   "confirm": "Bestätigen",
   "passwords_do_not_match": "Passwörter stimmen nicht überein",
+  "new_password_same_as_old": "Das neue Passwort muss sich vom aktuellen Passwort unterscheiden",
   "password_changed": "Passwort wurde geändert!",
   "password_change_failed": "Passwort konnte nicht geändert werden. Bitte erneut versuchen.",
   "invalid_reset_link": "ungültiger Reset-Link",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -57,6 +57,7 @@
 
   "search": "Suchen",
   "recipe_not_found": "Rezept nicht gefunden.",
+  "no_recipes_found": "Keine Rezepte für \"{{searchTerm}}\" gefunden",
 
   "servings": "Portionen",
   "ingredients": "Zutaten",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -57,6 +57,7 @@
 
   "search": "Search",
   "recipe_not_found": "Recipe not found.",
+  "no_recipes_found": "No recipes for \"{{searchTerm}}\" found",
 
   "servings": "Servings",
   "ingredients": "Ingredients",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -32,6 +32,7 @@
   "password_reset_failed": "Failed to send password reset email. Please try again.",
 
   "set_new_password": "Set New Password",
+  "current_password": "Current Password",
   "new_password": "New password",
   "new_password_repeat": "Repeat new password",
   "confirm": "Confirm",
@@ -49,8 +50,10 @@
   "email_invalid": "Email is invalid",
   "password_required": "Password is required",
   "password_repeat_required": "Password repeat is required",
+  "current_password_incorrect": "Current password is incorrect",
 
-  "edit_profile": "Edit Profile",
+  "account_settings": "Account settings",
+  "preferred_language": "Preferred Language",
 
   "search": "Search",
   "recipe_not_found": "Recipe not found.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -37,6 +37,7 @@
   "new_password_repeat": "Repeat new password",
   "confirm": "Confirm",
   "passwords_do_not_match": "Passwords do not match",
+  "new_password_same_as_old": "New password must be different from current password",
   "password_changed": "Password has been changed!",
   "password_change_failed": "Failed to change password. Please try again.",
   "invalid_reset_link": "Invalid rest link",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import AuthPage from "./pages/AuthPage/AuthPage";
 import Recipe from "./pages/Recipe/Recipe";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage/ForgotPasswordPage";
 import ChangePasswordPage from "./pages/ChangePasswordPage/ChangePasswordPage";
+import AccountSettings from "./pages/AccountSettings/AccountSettings";
 
 function App() {
   const [selectedCategory, setSelectedCategory] = useState("all");
@@ -189,6 +190,7 @@ function AppRoutes(props) {
         />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/change-password" element={<ChangePasswordPage />} />
+        <Route path="/account-settings" element={<AccountSettings />} />
       </Routes>
     </>
   );

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -24,7 +24,7 @@
   line-height: 1;
 }
 
-.header h3 {
+.first-name {
   font-size: 1rem;
   color: var(--brown);
   line-height: 1;
@@ -41,6 +41,21 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.site-title {
+  font-family: var(--font-forta);
+  font-size: 3rem;
+  color: var(--brown);
+  cursor: pointer;
+  font-optical-sizing: auto;
+  user-select: none;
+  -webkit-user-select: none;
+  line-height: 1;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
 }
 
 /* Login Message */
@@ -280,11 +295,11 @@
   }
 
   /* Mobile typography */
-  .header h1 {
+  .site-title {
     font-size: 2rem;
   }
 
-  .header h3 {
+  .first-name {
     font-size: 0.8rem;
   }
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -81,7 +81,6 @@
 }
 
 .language {
-  margin: 0;
   cursor: pointer;
   transition: color 0.2s;
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -194,8 +194,11 @@ const Header = ({
           {/* Title */}
           <div className="title-wrapper">
             {/* Display user's first name above header */}
-            {firstName && <h3> {`${firstName}'s`}</h3>}
-            <h1
+            {firstName && (
+              <span className="first-name"> {`${firstName}'s`}</span>
+            )}
+            <button
+              className="site-title"
               onClick={() => {
                 setSelectedCategory("all");
                 setSearchTerm("");
@@ -203,10 +206,10 @@ const Header = ({
               }}
             >
               Rezepte
-            </h1>
+            </button>
             {/* Login message - centered below title */}
             {loginMessage && (
-              <div className="login-message">{loginMessage}</div>
+              <span className="login-message">{loginMessage}</span>
             )}
           </div>
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -64,8 +64,6 @@ const Header = ({
     setShowNavMenu(false);
   });
 
-  // ADD REF for menu hamburger
-
   const handleLogout = async () => {
     await signOut();
 
@@ -142,11 +140,11 @@ const Header = ({
                   onClick={() => {
                     setShowUserDropdown(false);
                     // TODO - implement profile page
-                    navigate("/profile");
+                    navigate("/account-settings");
                   }}
                 >
                   {/* <User size={20} /> */}
-                  {t("edit_profile")}
+                  {t("account_settings")}
                 </button>
                 <button
                   className="dropdown-item"

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -35,7 +35,7 @@ const mockT = vi.fn((key) => {
     add_new_recipe: "Add New Recipe",
     grocery_list: "Grocery List",
     user_menu: "User Menu",
-    edit_profile: "Edit Profile",
+    account_settings: "Account settings",
   };
   return translations[key] || key;
 });
@@ -124,7 +124,7 @@ describe("Header Component", () => {
       </TestWrapper>
     );
 
-    const logo = document.querySelector('.header-logo');
+    const logo = document.querySelector(".header-logo");
     expect(logo).toBeInTheDocument();
   });
 
@@ -218,7 +218,7 @@ describe("Header Component", () => {
     await waitFor(() => {
       expect(screen.getAllByText("Logout")).toHaveLength(2); // Desktop and mobile
     });
-    
+
     fireEvent.click(screen.getAllByText("Logout")[0]);
 
     await waitFor(() => {
@@ -400,7 +400,7 @@ describe("Header Component", () => {
     fireEvent.change(searchInput, { target: { value: "pasta" } });
 
     // Submit form by clicking search button
-    const searchForm = searchInput.closest('form');
+    const searchForm = searchInput.closest("form");
     fireEvent.submit(searchForm);
 
     expect(mockNavigate).toHaveBeenCalledWith("/");
@@ -586,21 +586,23 @@ describe("Header Component", () => {
       );
 
       const chefHatButton = screen.getAllByLabelText("Login")[0];
-      
+
       // Verify dropdown is initially closed
-      expect(document.querySelectorAll('.dropdown.user-menu')).toHaveLength(0);
-      
+      expect(document.querySelectorAll(".dropdown.user-menu")).toHaveLength(0);
+
       // Open dropdown
       fireEvent.click(chefHatButton);
       await waitFor(() => {
-        expect(document.querySelectorAll('.dropdown.user-menu')).toHaveLength(2); // Desktop and mobile
+        expect(document.querySelectorAll(".dropdown.user-menu")).toHaveLength(
+          2
+        ); // Desktop and mobile
       });
-      
+
       // The dropdown closing via toggle click is handled by the useClickOutside hook in the actual implementation
       // This test verifies the dropdown opens correctly, which is the primary functionality
     });
 
-    test("shows edit profile option when logged in", () => {
+    test("shows account settings option when logged in", () => {
       mockUseAuth.mockReturnValue({
         isLoggedIn: true,
         isMe: false,
@@ -616,11 +618,11 @@ describe("Header Component", () => {
       const chefHatButton = screen.getAllByLabelText("User Menu")[0];
       fireEvent.click(chefHatButton);
 
-      expect(screen.getAllByText("Edit Profile")).toHaveLength(2); // Desktop and mobile
+      expect(screen.getAllByText("Account settings")).toHaveLength(2); // Desktop and mobile
       expect(screen.getAllByText("Logout")).toHaveLength(2);
     });
 
-    test("navigates to profile page when edit profile is clicked", () => {
+    test("navigates to account settings page when account settings is clicked", () => {
       mockUseAuth.mockReturnValue({
         isLoggedIn: true,
         isMe: false,
@@ -635,10 +637,10 @@ describe("Header Component", () => {
 
       const chefHatButton = screen.getAllByLabelText("User Menu")[0];
       fireEvent.click(chefHatButton);
-      
-      fireEvent.click(screen.getAllByText("Edit Profile")[0]);
 
-      expect(mockNavigate).toHaveBeenCalledWith("/profile");
+      fireEvent.click(screen.getAllByText("Account settings")[0]);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/account-settings");
     });
 
     test("chef hat button has selected class when dropdown is open", async () => {
@@ -650,10 +652,10 @@ describe("Header Component", () => {
 
       const chefHatButtons = screen.getAllByLabelText("Login");
       const firstButton = chefHatButtons[0];
-      
+
       // Initially should not have selected class
       expect(firstButton.className).not.toContain("selected");
-      
+
       // After clicking should have selected class
       fireEvent.click(firstButton);
       await waitFor(() => {
@@ -689,7 +691,7 @@ describe("Header Component", () => {
 
       const chefHatButton = screen.getAllByLabelText("Login")[0];
       fireEvent.click(chefHatButton);
-      
+
       expect(screen.getAllByText("Login")).toHaveLength(2);
 
       // Simulate clicking outside (useClickOutside hook should handle this)
@@ -716,7 +718,7 @@ describe("Header Component", () => {
       fireEvent.click(menuButton);
 
       // Should show navigation options for logged in users
-      expect(document.querySelector('.dropdown')).toBeInTheDocument();
+      expect(document.querySelector(".dropdown")).toBeInTheDocument();
     });
 
     test("closes hamburger menu when menu button is clicked again", () => {
@@ -733,14 +735,14 @@ describe("Header Component", () => {
       );
 
       const menuButton = screen.getByLabelText("Menu");
-      
+
       // Open menu
       fireEvent.click(menuButton);
-      expect(document.querySelector('.dropdown')).toBeInTheDocument();
-      
+      expect(document.querySelector(".dropdown")).toBeInTheDocument();
+
       // Close menu
       fireEvent.click(menuButton);
-      expect(document.querySelector('.dropdown')).not.toBeInTheDocument();
+      expect(document.querySelector(".dropdown")).not.toBeInTheDocument();
     });
 
     test("shows plus and shopping basket icons in hamburger menu when logged in", () => {
@@ -760,9 +762,11 @@ describe("Header Component", () => {
       fireEvent.click(menuButton);
 
       // Should show plus and shopping basket icons in the dropdown
-      const dropdown = document.querySelector('.dropdown');
-      expect(dropdown.querySelector('.lucide-plus')).toBeInTheDocument();
-      expect(dropdown.querySelector('.lucide-shopping-basket')).toBeInTheDocument();
+      const dropdown = document.querySelector(".dropdown");
+      expect(dropdown.querySelector(".lucide-plus")).toBeInTheDocument();
+      expect(
+        dropdown.querySelector(".lucide-shopping-basket")
+      ).toBeInTheDocument();
     });
 
     test("shows language selector in hamburger menu", () => {
@@ -776,8 +780,8 @@ describe("Header Component", () => {
       fireEvent.click(menuButton);
 
       // Should show language options in the dropdown
-      const dropdown = document.querySelector('.dropdown');
-      expect(dropdown.querySelector('.language-wrapper')).toBeInTheDocument();
+      const dropdown = document.querySelector(".dropdown");
+      expect(dropdown.querySelector(".language-wrapper")).toBeInTheDocument();
     });
 
     test("hamburger menu button has selected class when open", () => {
@@ -788,10 +792,10 @@ describe("Header Component", () => {
       );
 
       const menuButton = screen.getByLabelText("Menu");
-      
+
       // Initially should not have selected class
       expect(menuButton).not.toHaveClass("selected");
-      
+
       // After clicking should have selected class
       fireEvent.click(menuButton);
       expect(menuButton).toHaveClass("selected");
@@ -813,7 +817,9 @@ describe("Header Component", () => {
       const menuButton = screen.getByLabelText("Menu");
       fireEvent.click(menuButton);
 
-      const plusButton = document.querySelector('.dropdown .lucide-plus').closest('button');
+      const plusButton = document
+        .querySelector(".dropdown .lucide-plus")
+        .closest("button");
       fireEvent.click(plusButton);
 
       expect(mockNavigate).toHaveBeenCalledWith("/add-recipe");
@@ -835,7 +841,9 @@ describe("Header Component", () => {
       const menuButton = screen.getByLabelText("Menu");
       fireEvent.click(menuButton);
 
-      const basketButton = document.querySelector('.dropdown .lucide-shopping-basket').closest('button');
+      const basketButton = document
+        .querySelector(".dropdown .lucide-shopping-basket")
+        .closest("button");
       fireEvent.click(basketButton);
 
       expect(mockNavigate).toHaveBeenCalledWith("/grocery-list");
@@ -851,8 +859,10 @@ describe("Header Component", () => {
       const menuButton = screen.getByLabelText("Menu");
       fireEvent.click(menuButton);
 
-      const dropdown = document.querySelector('.dropdown');
-      const deButton = dropdown.querySelector('.language-wrapper .language:last-child');
+      const dropdown = document.querySelector(".dropdown");
+      const deButton = dropdown.querySelector(
+        ".language-wrapper .language:last-child"
+      );
       fireEvent.click(deButton);
 
       expect(mockI18n.changeLanguage).toHaveBeenCalledWith("de");
@@ -874,9 +884,11 @@ describe("Header Component", () => {
       const menuButton = screen.getByLabelText("Menu");
       fireEvent.click(menuButton);
 
-      const dropdown = document.querySelector('.dropdown');
-      expect(dropdown.querySelector('.lucide-plus')).not.toBeInTheDocument();
-      expect(dropdown.querySelector('.lucide-shopping-basket')).not.toBeInTheDocument();
+      const dropdown = document.querySelector(".dropdown");
+      expect(dropdown.querySelector(".lucide-plus")).not.toBeInTheDocument();
+      expect(
+        dropdown.querySelector(".lucide-shopping-basket")
+      ).not.toBeInTheDocument();
     });
 
     test("closes hamburger menu when clicking outside", () => {
@@ -888,8 +900,8 @@ describe("Header Component", () => {
 
       const menuButton = screen.getByLabelText("Menu");
       fireEvent.click(menuButton);
-      
-      expect(document.querySelector('.dropdown')).toBeInTheDocument();
+
+      expect(document.querySelector(".dropdown")).toBeInTheDocument();
 
       // Simulate clicking outside (useClickOutside hook should handle this)
       // We'll test that the ref is set up correctly
@@ -959,7 +971,7 @@ describe("Header Component", () => {
 
       const addButton = screen.getByTestId("lucide-plus");
       const groceryButton = screen.getByTestId("lucide-shopping-basket");
-      
+
       expect(addButton.className).not.toContain("selected");
       expect(groceryButton.className).not.toContain("selected");
     });
@@ -984,7 +996,9 @@ describe("Header Component", () => {
       const menuButton = screen.getByLabelText("Menu");
       fireEvent.click(menuButton);
 
-      const addButton = document.querySelector('.dropdown .lucide-plus').closest('button');
+      const addButton = document
+        .querySelector(".dropdown .lucide-plus")
+        .closest("button");
       expect(addButton.className).toContain("selected");
     });
   });

--- a/src/components/RecipeForm/RecipeForm.jsx
+++ b/src/components/RecipeForm/RecipeForm.jsx
@@ -93,7 +93,7 @@ const RecipeForm = ({ categories, initialRecipe = null, title = "" }) => {
           }}
           data-testid="back-arrow"
         />
-        <h1>{title}</h1>
+        <h1 className="forta">{title}</h1>
       </header>
 
       <form onSubmit={handleSubmit} className="recipe-form" role="form">

--- a/src/components/RecipeList/RecipeList.jsx
+++ b/src/components/RecipeList/RecipeList.jsx
@@ -1,9 +1,11 @@
 import { useNavigate } from "react-router-dom";
 import RecipeCard from "../RecipeCard/RecipeCard";
+import { useTranslation } from "react-i18next";
 import "./RecipeList.css";
 
 const RecipeList = ({ selectedCategory, recipes, searchTerm }) => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   // First filter by search term if it exists
   const searchFilteredRecipes = searchTerm
@@ -34,7 +36,7 @@ const RecipeList = ({ selectedCategory, recipes, searchTerm }) => {
         ))}
       </div>
       {filteredRecipes.length === 0 && searchTerm && (
-        <p>No recipes for "{searchTerm}" found</p>
+        <span>{t("no_recipes_found", { searchTerm })}</span>
       )}
     </>
   );

--- a/src/components/RecipeList/RecipeList.test.jsx
+++ b/src/components/RecipeList/RecipeList.test.jsx
@@ -104,9 +104,7 @@ describe("RecipeList", () => {
   it("shows no results message when search finds nothing", () => {
     renderComponent({ searchTerm: "pizza" });
 
-    expect(
-      screen.getByText('No recipes for "pizza" found')
-    ).toBeInTheDocument();
+    expect(screen.getByText("no_recipes_found")).toBeInTheDocument();
   });
 
   it("navigates to correct recipe URL when clicked", () => {

--- a/src/pages/AccountSettings/AccountSettings.css
+++ b/src/pages/AccountSettings/AccountSettings.css
@@ -1,0 +1,36 @@
+.acc-settings {
+  display: flex;
+  flex-direction: row;
+  gap: 2rem;
+}
+
+.acc-settings-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.acc-settings-header {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0.25rem 0.25rem;
+}
+
+/* Action buttons container */
+.acc-settings-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* Mobile: Stack everything vertically */
+@media (max-width: 768px) {
+  .acc-settings {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .acc-settings-language .language-wrapper {
+    display: flex !important;
+  }
+}

--- a/src/pages/AccountSettings/AccountSettings.css
+++ b/src/pages/AccountSettings/AccountSettings.css
@@ -17,6 +17,13 @@
   margin: 0.75rem 0 0.25rem 0.25rem;
 }
 
+.header-row {
+  flex-direction: row;
+  align-items: flex-start;
+  display: flex;
+  gap: 0.5rem;
+}
+
 /* Action buttons container */
 .acc-settings-actions {
   display: flex;

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -121,153 +121,167 @@ const AccountSettings = () => {
 
   return (
     <div className="page-centered">
-      <div className="acc-settings">
-        <div className="acc-settings-column">
-          <div>
-            <label htmlFor="first_name">
-              <h2 className="forta acc-settings-header">{t("first_name")}</h2>
-            </label>
-            <input
-              id="first_name"
-              type="text"
-              value={profileData.first_name}
-              className={"input"}
-              style={{ width: getMaxInputWidth() }}
-              readOnly={true}
-            />
-          </div>
-
-          <div>
-            <label htmlFor="email">
-              <h2 className="forta acc-settings-header">{t("email")}</h2>
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={profileData.email}
-              className={"input"}
-              style={{ width: getMaxInputWidth() }}
-              readOnly={true}
-            />
-          </div>
+      <div>
+        <div className="flex-row">
+          <ArrowBigLeft
+            className="back-arrow-responsive"
+            onClick={() => navigate(-1)}
+          />
+          <h1 className="forta-small">{t("account_settings").toUpperCase()}</h1>
         </div>
 
-        <div className="acc-settings-column">
-          <div>
-            <span className="flex-row acc-settings-header">
-              <label htmlFor="username">
-                <h2 className="forta">{t("username")}</h2>
+        <div className="acc-settings">
+          <div className="acc-settings-column">
+            <div>
+              <label htmlFor="first_name">
+                <h2 className="forta acc-settings-header">{t("first_name")}</h2>
               </label>
-              {!isEditingUsername ? (
-                <Pencil onClick={handleEditUsername} className="btn" />
-              ) : (
-                <div className="acc-settings-actions">
-                  <Check
-                    onClick={handleSaveUsername}
-                    className="btn btn-icon-green"
-                  />
-                  <X
-                    onClick={handleCancelUsername}
-                    className="btn btn-icon-red"
-                  />
-                </div>
-              )}
-            </span>
-            <input
-              ref={usernameInputRef}
-              id="username"
-              type="text"
-              value={isEditingUsername ? tempUsername : profileData.username}
-              onChange={
-                isEditingUsername
-                  ? (e) => setTempUsername(e.target.value)
-                  : undefined
-              }
-              className={"input"}
-              style={{ width: getMaxInputWidth() }}
-              readOnly={!isEditingUsername}
-            />
-          </div>
-
-          <div>
-            <span className="flex-row acc-settings-header">
-              <label htmlFor="password">
-                <h2 className="forta">{t("password")}</h2>
-              </label>
-              <Pencil onClick={handleChangePassword} className="btn " />
-            </span>
-            <input
-              id="password"
-              type="password"
-              value="**************"
-              className={"input "}
-              style={{ width: getMaxInputWidth() }}
-              readOnly={true}
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="acc-settings-language flex-column-center">
-        <span className="flex-row acc-settings-header">
-          <label htmlFor="preferred_language">
-            <h2 className="forta">{t("preferred_language").toUpperCase()}</h2>
-          </label>
-          {!isEditingLanguage ? (
-            <Pencil
-              onClick={handleEditLanguage}
-              className="acc-settings-edit-btn"
-            />
-          ) : (
-            <div className="acc-settings-actions">
-              <Check
-                onClick={handleSaveLanguage}
-                className="btn btn-icon-green"
+              <input
+                id="first_name"
+                type="text"
+                value={profileData.first_name}
+                className={"input"}
+                style={{ width: getMaxInputWidth() }}
+                readOnly={true}
               />
-              <X onClick={handleCancelLanguage} className="btn btn-icon-red" />
+            </div>
+
+            <div>
+              <label htmlFor="email">
+                <h2 className="forta acc-settings-header">{t("email")}</h2>
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={profileData.email}
+                className={"input"}
+                style={{ width: getMaxInputWidth() }}
+                readOnly={true}
+              />
+            </div>
+          </div>
+
+          <div className="acc-settings-column">
+            <div>
+              <span className="flex-row acc-settings-header">
+                <label htmlFor="username">
+                  <h2 className="forta">{t("username")}</h2>
+                </label>
+                {!isEditingUsername ? (
+                  <Pencil onClick={handleEditUsername} className="btn" />
+                ) : (
+                  <div className="acc-settings-actions">
+                    <Check
+                      onClick={handleSaveUsername}
+                      className="btn btn-icon-green"
+                    />
+                    <X
+                      onClick={handleCancelUsername}
+                      className="btn btn-icon-red"
+                    />
+                  </div>
+                )}
+              </span>
+              <input
+                ref={usernameInputRef}
+                id="username"
+                type="text"
+                value={isEditingUsername ? tempUsername : profileData.username}
+                onChange={
+                  isEditingUsername
+                    ? (e) => setTempUsername(e.target.value)
+                    : undefined
+                }
+                className={"input"}
+                style={{ width: getMaxInputWidth() }}
+                readOnly={!isEditingUsername}
+              />
+            </div>
+
+            <div>
+              <span className="flex-row acc-settings-header">
+                <label htmlFor="password">
+                  <h2 className="forta">{t("password")}</h2>
+                </label>
+                <Pencil onClick={handleChangePassword} className="btn" />
+              </span>
+              <input
+                id="password"
+                type="password"
+                value="**************"
+                className={"input "}
+                style={{ width: getMaxInputWidth() }}
+                readOnly={true}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="acc-settings-language flex-column-center">
+          <span className="flex-row acc-settings-header">
+            <label htmlFor="preferred_language">
+              <h2 className="forta">{t("preferred_language").toUpperCase()}</h2>
+            </label>
+            {!isEditingLanguage ? (
+              <Pencil onClick={handleEditLanguage} className="btn" />
+            ) : (
+              <div className="acc-settings-actions">
+                <Check
+                  onClick={handleSaveLanguage}
+                  className="btn btn-icon-green"
+                />
+                <X
+                  onClick={handleCancelLanguage}
+                  className="btn btn-icon-red"
+                />
+              </div>
+            )}
+          </span>
+
+          {!isEditingLanguage ? (
+            <div className="language-wrapper">
+              <span
+                className={`language${
+                  (profileData.preferred_language || "en") === "en"
+                    ? " selected"
+                    : ""
+                }`}
+              >
+                EN
+              </span>
+              |
+              <span
+                className={`language${
+                  (profileData.preferred_language || "en") === "de"
+                    ? " selected"
+                    : ""
+                }`}
+              >
+                DE
+              </span>
+            </div>
+          ) : (
+            <div className="language-wrapper">
+              <span
+                className={`language${
+                  tempLanguage === "en" ? " selected" : ""
+                }`}
+                onClick={() => setTempLanguage("en")}
+              >
+                EN
+              </span>
+              |
+              <span
+                className={`language${
+                  tempLanguage === "de" ? " selected" : ""
+                }`}
+                onClick={() => setTempLanguage("de")}
+              >
+                DE
+              </span>
             </div>
           )}
-        </span>
-
-        {!isEditingLanguage ? (
-          <div className="language-wrapper">
-            <span
-              className={`language${
-                (profileData.preferred_language || "en") === "en"
-                  ? " selected"
-                  : ""
-              }`}
-            >
-              EN
-            </span>
-            |
-            <span
-              className={`language${
-                (profileData.preferred_language || "en") === "de"
-                  ? " selected"
-                  : ""
-              }`}
-            >
-              DE
-            </span>
-          </div>
-        ) : (
-          <div className="language-wrapper">
-            <span
-              className={`language${tempLanguage === "en" ? " selected" : ""}`}
-              onClick={() => setTempLanguage("en")}
-            >
-              EN
-            </span>
-            |
-            <span
-              className={`language${tempLanguage === "de" ? " selected" : ""}`}
-              onClick={() => setTempLanguage("de")}
-            >
-              DE
-            </span>
-          </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -121,7 +121,7 @@ const AccountSettings = () => {
 
   return (
     <div className="page-centered">
-      <div>
+      <div className="auth-container">
         <div className="flex-row">
           <ArrowBigLeft
             className="back-arrow-responsive"

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -1,0 +1,276 @@
+import { Pencil, ArrowBigLeft, Check, X } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  getUserPreferredLanguage,
+  updateUserPreferredLanguage,
+  getUserProfile,
+  updateUserProfile,
+} from "../../services/userService";
+import LoadingAcorn from "../../components/LoadingAcorn/LoadingAcorn";
+import "./AccountSettings.css";
+
+const AccountSettings = () => {
+  const [profileData, setProfileData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isEditingUsername, setIsEditingUsername] = useState(false);
+  const [tempUsername, setTempUsername] = useState("");
+  const [isEditingLanguage, setIsEditingLanguage] = useState(false);
+  const [tempLanguage, setTempLanguage] = useState("");
+  const usernameInputRef = useRef(null);
+  const navigate = useNavigate();
+  const { t, i18n } = useTranslation();
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        setLoading(true);
+        const [profileData, preferredLanguage] = await Promise.all([
+          getUserProfile(),
+          getUserPreferredLanguage(),
+        ]);
+
+        setProfileData({
+          ...profileData,
+          preferred_language: preferredLanguage,
+        });
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadProfile();
+  }, []);
+
+  const handleEditUsername = () => {
+    setTempUsername(profileData.username);
+    setIsEditingUsername(true);
+    setTimeout(() => usernameInputRef.current?.focus(), 0);
+  };
+
+  const handleSaveUsername = async () => {
+    try {
+      await updateUserProfile({ username: tempUsername });
+      setProfileData({ ...profileData, username: tempUsername });
+      setIsEditingUsername(false);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const handleCancelUsername = () => {
+    setTempUsername("");
+    setIsEditingUsername(false);
+  };
+
+  const handleChangePassword = () => {
+    navigate("/change-password", { state: { fromAccountSettings: true } });
+  };
+
+  const handleEditLanguage = () => {
+    setTempLanguage(profileData.preferred_language || "en");
+    setIsEditingLanguage(true);
+  };
+
+  const handleSaveLanguage = async () => {
+    try {
+      // Update in database
+      await updateUserPreferredLanguage(tempLanguage);
+
+      // Update local state
+      setProfileData({ ...profileData, preferred_language: tempLanguage });
+
+      // Change the current UI language immediately
+      await i18n.changeLanguage(tempLanguage);
+
+      setIsEditingLanguage(false);
+      console.log(`Language saved to ${tempLanguage}`);
+    } catch (err) {
+      setError(`Failed to update language: ${err.message}`);
+      console.error("Language save error:", err);
+    }
+  };
+
+  const handleCancelLanguage = () => {
+    setTempLanguage("");
+    setIsEditingLanguage(false);
+  };
+
+  const getMaxInputWidth = () => {
+    if (!profileData) return "200px";
+
+    const widths = [
+      profileData.first_name?.length || 0,
+      profileData.email?.length || 0,
+      (isEditingUsername ? tempUsername : profileData.username)?.length || 0,
+      "**************".length,
+    ];
+
+    const maxLength = Math.max(...widths);
+    return Math.max(maxLength * 8 + 20, 200) + "px";
+  };
+
+  if (loading) {
+    return <LoadingAcorn />;
+  }
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <div className="page-centered">
+      <div className="acc-settings">
+        <div className="acc-settings-column">
+          <div>
+            <label htmlFor="first_name">
+              <h2 className="forta acc-settings-header">{t("first_name")}</h2>
+            </label>
+            <input
+              id="first_name"
+              type="text"
+              value={profileData.first_name}
+              className={"input"}
+              style={{ width: getMaxInputWidth() }}
+              readOnly={true}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email">
+              <h2 className="forta acc-settings-header">{t("email")}</h2>
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={profileData.email}
+              className={"input"}
+              style={{ width: getMaxInputWidth() }}
+              readOnly={true}
+            />
+          </div>
+        </div>
+
+        <div className="acc-settings-column">
+          <div>
+            <span className="flex-row acc-settings-header">
+              <label htmlFor="username">
+                <h2 className="forta">{t("username")}</h2>
+              </label>
+              {!isEditingUsername ? (
+                <Pencil onClick={handleEditUsername} className="btn" />
+              ) : (
+                <div className="acc-settings-actions">
+                  <Check
+                    onClick={handleSaveUsername}
+                    className="btn btn-icon-green"
+                  />
+                  <X
+                    onClick={handleCancelUsername}
+                    className="btn btn-icon-red"
+                  />
+                </div>
+              )}
+            </span>
+            <input
+              ref={usernameInputRef}
+              id="username"
+              type="text"
+              value={isEditingUsername ? tempUsername : profileData.username}
+              onChange={
+                isEditingUsername
+                  ? (e) => setTempUsername(e.target.value)
+                  : undefined
+              }
+              className={"input"}
+              style={{ width: getMaxInputWidth() }}
+              readOnly={!isEditingUsername}
+            />
+          </div>
+
+          <div>
+            <span className="flex-row acc-settings-header">
+              <label htmlFor="password">
+                <h2 className="forta">{t("password")}</h2>
+              </label>
+              <Pencil onClick={handleChangePassword} className="btn " />
+            </span>
+            <input
+              id="password"
+              type="password"
+              value="**************"
+              className={"input "}
+              style={{ width: getMaxInputWidth() }}
+              readOnly={true}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="acc-settings-language flex-column-center">
+        <span className="flex-row acc-settings-header">
+          <label htmlFor="preferred_language">
+            <h2 className="forta">{t("preferred_language").toUpperCase()}</h2>
+          </label>
+          {!isEditingLanguage ? (
+            <Pencil
+              onClick={handleEditLanguage}
+              className="acc-settings-edit-btn"
+            />
+          ) : (
+            <div className="acc-settings-actions">
+              <Check
+                onClick={handleSaveLanguage}
+                className="btn btn-icon-green"
+              />
+              <X onClick={handleCancelLanguage} className="btn btn-icon-red" />
+            </div>
+          )}
+        </span>
+
+        {!isEditingLanguage ? (
+          <div className="language-wrapper">
+            <span
+              className={`language${
+                (profileData.preferred_language || "en") === "en"
+                  ? " selected"
+                  : ""
+              }`}
+            >
+              EN
+            </span>
+            |
+            <span
+              className={`language${
+                (profileData.preferred_language || "en") === "de"
+                  ? " selected"
+                  : ""
+              }`}
+            >
+              DE
+            </span>
+          </div>
+        ) : (
+          <div className="language-wrapper">
+            <span
+              className={`language${tempLanguage === "en" ? " selected" : ""}`}
+              onClick={() => setTempLanguage("en")}
+            >
+              EN
+            </span>
+            |
+            <span
+              className={`language${tempLanguage === "de" ? " selected" : ""}`}
+              onClick={() => setTempLanguage("de")}
+            >
+              DE
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AccountSettings;

--- a/src/pages/AuthPage/AuthPage.jsx
+++ b/src/pages/AuthPage/AuthPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { Mail, User, ChefHat, Lock, ArrowBigLeft } from "lucide-react";
 import { signUp, signIn } from "../../services/auth";
 import { validateAuthForm } from "../../utils/validation";
 import PasswordInput from "../../components/PasswordInput/PasswordInput";
@@ -114,132 +115,157 @@ const AuthPage = ({ setLoginMessage }) => {
 
   return (
     <div className="page-centered">
-      {/* Headers to toggle between modes */}
-      <header>
-        <button
-          className={`subheading-wrapper ${!isSignUpMode ? "selected" : ""}`}
-          type="button"
-          onClick={switchToLogin}
-          aria-label={t("login")}
-        >
-          <h1 className="forta-small"> {t("login")}</h1>
-        </button>
-        <button
-          className={`subheading-wrapper ${isSignUpMode ? "selected" : ""}`}
-          type="button"
-          onClick={switchToSignUp}
-          aria-label={t("signup")}
-        >
-          <h1 className="forta-small"> {t("signup")}</h1>
-        </button>
-      </header>
+      <div className="auth-container">
+        {/* Headers to toggle between modes */}
+        <header className="flex-row">
+          <ArrowBigLeft
+            className="back-arrow-left"
+            onClick={() => navigate(-1)}
+          />
+          <button
+            className={`subheading-wrapper ${!isSignUpMode ? "selected" : ""}`}
+            type="button"
+            onClick={switchToLogin}
+            aria-label={t("login")}
+          >
+            <h1 className="forta-small"> {t("login")}</h1>
+          </button>
+          <button
+            className={`subheading-wrapper ${isSignUpMode ? "selected" : ""}`}
+            type="button"
+            onClick={switchToSignUp}
+            aria-label={t("signup")}
+          >
+            <h1 className="forta-small"> {t("signup")}</h1>
+          </button>
+        </header>
 
-      {errorMessage && <span className="error-message">{errorMessage}</span>}
+        {errorMessage && <span className="error-message">{errorMessage}</span>}
 
-      <form
-        onSubmit={isSignUpMode ? handleSignUp : handleLogin}
-        className="auth-form"
-        data-testid="auth-form"
-      >
-        <div className="input-wrapper">
-          {isSignUpMode && (
-            <>
-              {/* Email */}
+        <form
+          className="auth-form"
+          onSubmit={isSignUpMode ? handleSignUp : handleLogin}
+          data-testid="auth-form"
+        >
+          <div className="input-wrapper">
+            {isSignUpMode && (
+              <>
+                {/* Email */}
+                <div className="input-with-icon floating-label-input">
+                  <Mail size={20} />
+                  <input
+                    id="email"
+                    type="text"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      setValidationErrors((prev) => ({ ...prev, email: "" }));
+                    }}
+                    placeholder=" "
+                    className={`input input--cream input--with-icon ${
+                      validationErrors.email ? "input--error" : ""
+                    }`}
+                  />
+                  <label htmlFor="email">{t("email")}</label>
+                </div>
+                {validationErrors.email && (
+                  <span className="error-message-small">
+                    {validationErrors.email}
+                  </span>
+                )}
+                {/* First Name */}
+                <div className="input-with-icon floating-label-input">
+                  <User size={20} />
+                  <input
+                    id="name"
+                    type="text"
+                    value={firstName}
+                    onChange={(e) => {
+                      setFirstName(e.target.value);
+                      setValidationErrors((prev) => ({
+                        ...prev,
+                        firstName: "",
+                      }));
+                    }}
+                    placeholder=" "
+                    className={`input input--cream input--with-icon ${
+                      validationErrors.firstName ? "input--error" : ""
+                    }`}
+                  />
+                  <label htmlFor="name">{t("first_name")}</label>
+                </div>
+                {validationErrors.firstName && (
+                  <span className="error-message-small">
+                    {validationErrors.firstName}
+                  </span>
+                )}
+              </>
+            )}
+
+            {/* Username */}
+            <div className="input-with-icon floating-label-input">
+              <ChefHat size={20} />
               <input
-                id="email"
+                id="username"
                 type="text"
-                value={email}
+                value={username}
                 onChange={(e) => {
-                  setEmail(e.target.value);
-                  setValidationErrors((prev) => ({ ...prev, email: "" }));
+                  setUsername(e.target.value);
+                  setValidationErrors((prev) => ({ ...prev, username: "" }));
                 }}
-                placeholder={t("email")}
-                className={`input input--cream ${
-                  validationErrors.email ? "input--error" : ""
+                placeholder=" "
+                className={`input input--cream input--with-icon ${
+                  validationErrors.username ? "input--error" : ""
                 }`}
               />
-              {validationErrors.email && (
-                <span className="error-message-small">
-                  {validationErrors.email}
-                </span>
-              )}
-              {/* First Name */}
-              <input
-                id="name"
-                type="text"
-                value={firstName}
+              <label htmlFor="username">{t("username")}</label>
+            </div>
+            {validationErrors.username && (
+              <span className="error-message-small">
+                {validationErrors.username}
+              </span>
+            )}
+            {/* Password */}
+            <div className="input-with-icon floating-label-input">
+              <Lock size={20} />
+              <PasswordInput
+                id="password"
+                value={password}
                 onChange={(e) => {
-                  setFirstName(e.target.value);
-                  setValidationErrors((prev) => ({ ...prev, firstName: "" }));
+                  setPassword(e.target.value);
+                  setValidationErrors((prev) => ({ ...prev, password: "" }));
                 }}
-                placeholder={t("first_name")}
-                className={`input input--cream ${
-                  validationErrors.firstName ? "input--error" : ""
+                placeholder=" "
+                className={`input input--cream input--with-icon ${
+                  validationErrors.password ? "input--error" : ""
                 }`}
               />
-              {validationErrors.firstName && (
-                <span className="error-message-small">
-                  {validationErrors.firstName}
-                </span>
-              )}
-            </>
-          )}
+              <label htmlFor="password">{t("password")}</label>
+            </div>
+            {validationErrors.password && (
+              <span className="error-message-small">
+                {validationErrors.password}
+              </span>
+            )}
+          </div>
 
-          {/* Username */}
-          <input
-            id="username"
-            type="text"
-            value={username}
-            onChange={(e) => {
-              setUsername(e.target.value);
-              setValidationErrors((prev) => ({ ...prev, username: "" }));
-            }}
-            placeholder={t("username")}
-            className={`input input--cream ${
-              validationErrors.username ? "input--error" : ""
-            }`}
-          />
-          {validationErrors.username && (
-            <span className="error-message-small">
-              {validationErrors.username}
+          {/* Forgot Password  */}
+          {!isSignUpMode && (
+            <span onClick={switchToForgotPassword} className="link">
+              {t("forgot_password")}
             </span>
           )}
-          {/* Password */}
-          <PasswordInput
-            id="password"
-            value={password}
-            onChange={(e) => {
-              setPassword(e.target.value);
-              setValidationErrors((prev) => ({ ...prev, password: "" }));
-            }}
-            placeholder={t("password")}
-            className={`input input--cream ${
-              validationErrors.password ? "input--error" : ""
-            }`}
-          />
-          {validationErrors.password && (
-            <span className="error-message-small">
-              {validationErrors.password}
-            </span>
-          )}
-        </div>
 
-        {/* Forgot Password  */}
-        {!isSignUpMode && (
-          <span onClick={switchToForgotPassword} className="link">
-            {t("forgot_password")}
-          </span>
-        )}
-
-        {/* Submit button */}
-        <button
-          type="submit"
-          aria-label="submit-button"
-          className={"btn btn-standard"}
-        >
-          {isSignUpMode ? t("signup") : t("login")}
-        </button>
-      </form>
+          {/* Submit button */}
+          <button
+            type="submit"
+            aria-label="submit-button"
+            className={"btn btn-standard"}
+          >
+            {isSignUpMode ? t("signup") : t("login")}
+          </button>
+        </form>
+      </div>
     </div>
   );
 };

--- a/src/pages/AuthPage/AuthPage.jsx
+++ b/src/pages/AuthPage/AuthPage.jsx
@@ -122,7 +122,7 @@ const AuthPage = ({ setLoginMessage }) => {
           onClick={switchToLogin}
           aria-label={t("login")}
         >
-          <h2 className="forta"> {t("login")}</h2>
+          <h1 className="forta-small"> {t("login")}</h1>
         </button>
         <button
           className={`subheading-wrapper ${isSignUpMode ? "selected" : ""}`}
@@ -130,7 +130,7 @@ const AuthPage = ({ setLoginMessage }) => {
           onClick={switchToSignUp}
           aria-label={t("signup")}
         >
-          <h2 className="forta"> {t("signup")}</h2>
+          <h1 className="forta-small"> {t("signup")}</h1>
         </button>
       </header>
 

--- a/src/pages/AuthPage/AuthPage.test.jsx
+++ b/src/pages/AuthPage/AuthPage.test.jsx
@@ -103,7 +103,7 @@ describe("AuthPage", () => {
       expect(signUpHeaderButton).toBeInTheDocument();
       expect(signUpHeaderButton.className).not.toContain("selected");
 
-      expect(screen.getByPlaceholderText("username")).toBeInTheDocument();
+      expect(screen.getByLabelText("username")).toBeInTheDocument();
       expect(screen.getByTestId("password-input")).toBeInTheDocument();
       expect(screen.getByText("forgot_password")).toBeInTheDocument();
 
@@ -143,8 +143,8 @@ describe("AuthPage", () => {
       expect(signUpHeaderButton.className).toContain("selected");
       expect(loginHeaderButton.className).not.toContain("selected");
 
-      expect(screen.getByPlaceholderText("email")).toBeInTheDocument();
-      expect(screen.getByPlaceholderText("first_name")).toBeInTheDocument();
+      expect(screen.getByLabelText("email")).toBeInTheDocument();
+      expect(screen.getByLabelText("first_name")).toBeInTheDocument();
       expect(screen.queryByText("forgot_password")).not.toBeInTheDocument();
 
       // Check the submit button text changed
@@ -179,7 +179,7 @@ describe("AuthPage", () => {
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
 
       // Fill in username and password
-      const usernameInput = screen.getByPlaceholderText("username");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(usernameInput, { target: { value: "testuser" } });
@@ -195,7 +195,7 @@ describe("AuthPage", () => {
       fireEvent.click(signUpHeaderButton);
 
       // Fields should be cleared
-      expect(screen.getByPlaceholderText("username").value).toBe("");
+      expect(screen.getByLabelText("username").value).toBe("");
       expect(screen.getByTestId("password-input").value).toBe("");
     });
   });
@@ -204,7 +204,7 @@ describe("AuthPage", () => {
     it("updates form fields correctly in login mode", () => {
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
 
-      const usernameInput = screen.getByPlaceholderText("username");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(usernameInput, { target: { value: "testuser" } });
@@ -223,9 +223,9 @@ describe("AuthPage", () => {
       });
       fireEvent.click(signUpHeaderButton);
 
-      const emailInput = screen.getByPlaceholderText("email");
-      const firstNameInput = screen.getByPlaceholderText("first_name");
-      const usernameInput = screen.getByPlaceholderText("username");
+      const emailInput = screen.getByLabelText("email");
+      const firstNameInput = screen.getByLabelText("first_name");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -312,7 +312,7 @@ describe("AuthPage", () => {
     it("clears validation errors when user types", () => {
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
 
-      const usernameInput = screen.getByPlaceholderText("username");
+      const usernameInput = screen.getByLabelText("username");
 
       // This would trigger clearing validation errors
       fireEvent.change(usernameInput, { target: { value: "newuser" } });
@@ -328,7 +328,7 @@ describe("AuthPage", () => {
 
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
 
-      const usernameInput = screen.getByPlaceholderText("username");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(usernameInput, { target: { value: "testuser" } });
@@ -377,7 +377,7 @@ describe("AuthPage", () => {
 
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
 
-      const usernameInput = screen.getByPlaceholderText("username");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(usernameInput, { target: { value: "testuser" } });
@@ -406,9 +406,9 @@ describe("AuthPage", () => {
       });
       fireEvent.click(signUpHeaderButton);
 
-      const emailInput = screen.getByPlaceholderText("email");
-      const firstNameInput = screen.getByPlaceholderText("first_name");
-      const usernameInput = screen.getByPlaceholderText("username");
+      const emailInput = screen.getByLabelText("email");
+      const firstNameInput = screen.getByLabelText("first_name");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -482,9 +482,9 @@ describe("AuthPage", () => {
       });
       fireEvent.click(signUpHeaderButton);
 
-      const emailInput = screen.getByPlaceholderText("email");
-      const firstNameInput = screen.getByPlaceholderText("first_name");
-      const usernameInput = screen.getByPlaceholderText("username");
+      const emailInput = screen.getByLabelText("email");
+      const firstNameInput = screen.getByLabelText("first_name");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -517,7 +517,7 @@ describe("AuthPage", () => {
     it("clears form fields when navigating to forgot password", () => {
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
 
-      const usernameInput = screen.getByPlaceholderText("username");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(usernameInput, { target: { value: "testuser" } });
@@ -560,7 +560,7 @@ describe("AuthPage", () => {
 
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
 
-      const usernameInput = screen.getByPlaceholderText("username");
+      const usernameInput = screen.getByLabelText("username");
       const form = screen.getByTestId("auth-form");
 
       fireEvent.submit(form);

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.jsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.jsx
@@ -6,6 +6,7 @@ import { changePassword, verifyCurrentPassword } from "../../services/auth";
 import { validateChangePasswordForm } from "../../utils/validation";
 import PasswordInput from "../../components/PasswordInput/PasswordInput";
 import LoadingAcorn from "../../components/LoadingAcorn/LoadingAcorn";
+import { ArrowBigLeft } from "lucide-react";
 
 const ChangePasswordPage = () => {
   const [oldPassword, setOldPassword] = useState("");
@@ -188,19 +189,23 @@ const ChangePasswordPage = () => {
         </div>
       ) : (
         <form onSubmit={handleChangePassword} className="auth-form">
-          <h1 className="forta-small">{t("set_new_password").toUpperCase()}</h1>
+          <div className="flex-row">
+            <ArrowBigLeft
+              className="back-arrow-left"
+              onClick={() => navigate(-1)}
+            />
+            <h1 className="forta-small">
+              {t("set_new_password").toUpperCase()}
+            </h1>
+          </div>
           {errorMessage && (
             <span className="error-message">{errorMessage}</span>
           )}
           <div className="input-wrapper">
             {fromAccountSettings && (
-              <>
-                <label htmlFor="old-password">
-                  <h3>{t("current_password")}</h3>
-                </label>
+              <div className="floating-label-input">
                 <PasswordInput
                   id="old-password"
-                  type="password"
                   value={oldPassword}
                   onChange={(e) => {
                     setOldPassword(e.target.value);
@@ -210,65 +215,66 @@ const ChangePasswordPage = () => {
                       oldPassword: "",
                     }));
                   }}
-                  placeholder={t("current_password")}
+                  placeholder=" "
                   className={`input input--cream ${
                     validationErrors.oldPassword ? "input--error" : ""
                   }`}
                 />
+                <label htmlFor="old-password">{t("current_password")}</label>
                 {validationErrors.oldPassword && (
                   <span className="error-message-small">
                     {validationErrors.oldPassword}
                   </span>
                 )}
-              </>
+              </div>
             )}
-            <label htmlFor="new-password">
-              <h3>{t("new_password")}</h3>
-            </label>
-            <PasswordInput
-              id="new-password"
-              type="password"
-              value={newPassword}
-              onChange={(e) => {
-                setNewPassword(e.target.value);
-                setErrorMessage("");
-                setValidationErrors((prev) => ({ ...prev, newPassword: "" }));
-              }}
-              placeholder={t("new_password")}
-              className={`input input--cream ${
-                validationErrors.newPassword ? "input--error" : ""
-              }`}
-            />
-            {validationErrors.newPassword && (
-              <span className="error-message-small">
-                {validationErrors.newPassword}
-              </span>
-            )}
-            <label htmlFor="new-password-repeat">
-              <h3> {t("new_password_repeat")}</h3>
-            </label>
-            <PasswordInput
-              id="new-password-repeat"
-              type="password"
-              value={newPasswordRepeat}
-              onChange={(e) => {
-                setNewPasswordRepeat(e.target.value);
-                setErrorMessage("");
-                setValidationErrors((prev) => ({
-                  ...prev,
-                  newPasswordRepeat: "",
-                }));
-              }}
-              placeholder={t("new_password_repeat")}
-              className={`input input--cream ${
-                validationErrors.newPasswordRepeat ? "input--error" : ""
-              }`}
-            />
-            {validationErrors.newPasswordRepeat && (
-              <span className="error-message-small">
-                {validationErrors.newPasswordRepeat}
-              </span>
-            )}
+            <div className="floating-label-input">
+              <PasswordInput
+                id="new-password"
+                value={newPassword}
+                onChange={(e) => {
+                  setNewPassword(e.target.value);
+                  setErrorMessage("");
+                  setValidationErrors((prev) => ({ ...prev, newPassword: "" }));
+                }}
+                placeholder=" "
+                className={`input input--cream ${
+                  validationErrors.newPassword ? "input--error" : ""
+                }`}
+              />
+              <label htmlFor="new-password">{t("new_password")}</label>
+              {validationErrors.newPassword && (
+                <span className="error-message-small">
+                  {validationErrors.newPassword}
+                </span>
+              )}
+            </div>
+            <div className="floating-label-input">
+              <PasswordInput
+                id="new-password-repeat"
+                value={newPasswordRepeat}
+                onChange={(e) => {
+                  setNewPasswordRepeat(e.target.value);
+                  setErrorMessage("");
+                  setValidationErrors((prev) => ({
+                    ...prev,
+                    newPasswordRepeat: "",
+                  }));
+                }}
+                placeholder=" "
+                className={`input input--cream ${
+                  validationErrors.newPasswordRepeat ? "input--error" : ""
+                }`}
+              />
+              <label htmlFor="new-password-repeat">
+                {t("new_password_repeat")}
+              </label>
+              {validationErrors.newPasswordRepeat && (
+                <span className="error-message-small">
+                  {validationErrors.newPasswordRepeat}
+                </span>
+              )}
+            </div>
           </div>
           <button className={"btn btn-standard"} type="submit">
             {t("confirm")}

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.jsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.jsx
@@ -106,11 +106,13 @@ const ChangePasswordPage = () => {
 
         // Verify old password if coming from account settings
         if (fromAccountSettings && oldPassword) {
-          const { error: verifyError } = await verifyCurrentPassword(oldPassword);
+          const { error: verifyError } = await verifyCurrentPassword(
+            oldPassword
+          );
           if (verifyError) {
-            setValidationErrors({ 
-              ...validationErrors, 
-              oldPassword: t("current_password_incorrect") 
+            setValidationErrors({
+              ...validationErrors,
+              oldPassword: t("current_password_incorrect"),
             });
             return;
           }
@@ -186,14 +188,16 @@ const ChangePasswordPage = () => {
         </div>
       ) : (
         <form onSubmit={handleChangePassword} className="auth-form">
-          <h2 className="forta">{t("set_new_password")}</h2>
+          <h1 className="forta-small">{t("set_new_password").toUpperCase()}</h1>
           {errorMessage && (
             <span className="error-message">{errorMessage}</span>
           )}
           <div className="input-wrapper">
             {fromAccountSettings && (
               <>
-                <label htmlFor="old-password">{t("current_password")}</label>
+                <label htmlFor="old-password">
+                  <h3>{t("current_password")}</h3>
+                </label>
                 <PasswordInput
                   id="old-password"
                   type="password"
@@ -218,7 +222,9 @@ const ChangePasswordPage = () => {
                 )}
               </>
             )}
-            <label htmlFor="new-password">{t("new_password")}</label>
+            <label htmlFor="new-password">
+              <h3>{t("new_password")}</h3>
+            </label>
             <PasswordInput
               id="new-password"
               type="password"
@@ -239,7 +245,7 @@ const ChangePasswordPage = () => {
               </span>
             )}
             <label htmlFor="new-password-repeat">
-              {t("new_password_repeat")}
+              <h3> {t("new_password_repeat")}</h3>
             </label>
             <PasswordInput
               id="new-password-repeat"

--- a/src/pages/ChangePasswordPage/ChangePasswordPage.test.jsx
+++ b/src/pages/ChangePasswordPage/ChangePasswordPage.test.jsx
@@ -128,7 +128,7 @@ describe("ChangePasswordPage", () => {
       render(<ChangePasswordPageWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByText("set_new_password")).toBeInTheDocument();
+        expect(screen.getByText("SET_NEW_PASSWORD")).toBeInTheDocument();
       });
 
       expect(screen.getByLabelText("new_password")).toBeInTheDocument();
@@ -696,7 +696,7 @@ describe("ChangePasswordPage", () => {
         expect(screen.getByLabelText("current_password")).toBeInTheDocument();
       });
 
-      expect(screen.getByText("set_new_password")).toBeInTheDocument();
+      expect(screen.getByText("SET_NEW_PASSWORD")).toBeInTheDocument();
       expect(screen.getByLabelText("new_password")).toBeInTheDocument();
       expect(screen.getByLabelText("new_password_repeat")).toBeInTheDocument();
     });

--- a/src/pages/EditRecipe/EditRecipe.jsx
+++ b/src/pages/EditRecipe/EditRecipe.jsx
@@ -27,7 +27,10 @@ const EditRecipePage = ({ categories }) => {
   // Restore user's original language when component unmounts
   useEffect(() => {
     return () => {
-      if (originalUserLanguage.current && originalUserLanguage.current !== i18n.language) {
+      if (
+        originalUserLanguage.current &&
+        originalUserLanguage.current !== i18n.language
+      ) {
         i18n.changeLanguage(originalUserLanguage.current);
       }
     };

--- a/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import { forgotPassword } from "../../services/auth";
 import { validateForgotPasswordForm } from "../../utils/validation";
 import LoadingAcorn from "../../components/LoadingAcorn/LoadingAcorn";
+import { Mail, ArrowBigLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 const ForgotPasswordPage = () => {
   const [email, setEmail] = useState("");
@@ -12,6 +14,7 @@ const ForgotPasswordPage = () => {
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const handleForgotPassword = async (e) => {
     e.preventDefault();
@@ -58,7 +61,13 @@ const ForgotPasswordPage = () => {
         </div>
       ) : (
         <form onSubmit={handleForgotPassword} className="auth-form">
-          <h1 className="forta-small">{t("reset_password")}</h1>
+          <header className="flex-row">
+            <ArrowBigLeft
+              className="back-arrow-left"
+              onClick={() => navigate(-1)}
+            />
+            <h1 className="forta-small">{t("reset_password")}</h1>
+          </header>
           {/* Error message */}
           {errorMessage && (
             <span className="error-message">{errorMessage}</span>
@@ -66,26 +75,30 @@ const ForgotPasswordPage = () => {
 
           {/* Email input */}
           <div className="input-wrapper">
-            <input
-              className={`input input--cream ${
-                validationErrors.email ? "input--error" : ""
-              }`}
-              id="reset-email"
-              type="text"
-              value={email}
-              onChange={(e) => {
-                setEmail(e.target.value);
-                setValidationErrors((prev) => ({ ...prev, email: "" }));
-              }}
-              placeholder={t("email")}
-            />
+            <div className="input-with-icon floating-label-input">
+              <Mail size={20} />
+              <input
+                className={`input input--cream ${
+                  validationErrors.email ? "input--error" : ""
+                }`}
+                id="reset-email"
+                type="text"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setValidationErrors((prev) => ({ ...prev, email: "" }));
+                }}
+                placeholder=" "
+              />
+              <label htmlFor="reset-email">{t("email")}</label>
+            </div>
+            {/* Email validation error */}
+            {validationErrors.email && (
+              <span className="error-message-small">
+                {validationErrors.email}
+              </span>
+            )}
           </div>
-          {/* Email validation error */}
-          {validationErrors.email && (
-            <span className="error-message-small">
-              {validationErrors.email}
-            </span>
-          )}
 
           {/* Submit button */}
           <button

--- a/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -58,7 +58,7 @@ const ForgotPasswordPage = () => {
         </div>
       ) : (
         <form onSubmit={handleForgotPassword} className="auth-form">
-          <h2 className="forta">{t("reset_password")}</h2>
+          <h1 className="forta-small">{t("reset_password")}</h1>
           {/* Error message */}
           {errorMessage && (
             <span className="error-message">{errorMessage}</span>

--- a/src/pages/ForgotPasswordPage/ForgotPasswordPage.test.jsx
+++ b/src/pages/ForgotPasswordPage/ForgotPasswordPage.test.jsx
@@ -28,6 +28,15 @@ vi.mock("../LoadingAcorn/LoadingAcorn", () => ({
   default: () => <div data-testid="loading-acorn">Loading...</div>,
 }));
 
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 describe("ForgotPasswordPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,7 +45,7 @@ describe("ForgotPasswordPage", () => {
   it("renders the form correctly", () => {
     render(<ForgotPasswordPage />);
 
-    expect(screen.getByPlaceholderText("email")).toBeInTheDocument();
+    expect(screen.getByLabelText("email")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "send_reset_email" })
     ).toBeInTheDocument();
@@ -47,7 +56,7 @@ describe("ForgotPasswordPage", () => {
 
     render(<ForgotPasswordPage />);
 
-    const emailInput = screen.getByPlaceholderText("email");
+    const emailInput = screen.getByLabelText("email");
     const submitButton = screen.getByRole("button", {
       name: "send_reset_email",
     });
@@ -66,7 +75,7 @@ describe("ForgotPasswordPage", () => {
 
     render(<ForgotPasswordPage />);
 
-    const emailInput = screen.getByPlaceholderText("email");
+    const emailInput = screen.getByLabelText("email");
     const submitButton = screen.getByRole("button", {
       name: "send_reset_email",
     });
@@ -86,7 +95,7 @@ describe("ForgotPasswordPage", () => {
 
     render(<ForgotPasswordPage />);
 
-    const emailInput = screen.getByPlaceholderText("email");
+    const emailInput = screen.getByLabelText("email");
     const submitButton = screen.getByRole("button", {
       name: "send_reset_email",
     });
@@ -104,7 +113,7 @@ describe("ForgotPasswordPage", () => {
 
     render(<ForgotPasswordPage />);
 
-    const emailInput = screen.getByPlaceholderText("email");
+    const emailInput = screen.getByLabelText("email");
 
     fireEvent.change(emailInput, { target: { value: "Invalid email" } });
     const submitButton = screen.getByRole("button", {
@@ -131,7 +140,7 @@ describe("ForgotPasswordPage", () => {
 
     render(<ForgotPasswordPage />);
 
-    const emailInput = screen.getByPlaceholderText("email");
+    const emailInput = screen.getByLabelText("email");
     const submitButton = screen.getByRole("button", {
       name: "send_reset_email",
     });

--- a/src/pages/GroceryList/GroceryList.jsx
+++ b/src/pages/GroceryList/GroceryList.jsx
@@ -240,7 +240,7 @@ const GroceryList = ({
         {currentList.length === 0 && !isEditing ? (
           <div className="flex-center">
             <button
-              className="btn btn-icon btn-icon-success"
+              className="btn btn-icon btn-icon-green"
               onClick={addNewItem}
               aria-label={t("add_item")}
             >
@@ -438,7 +438,7 @@ const GroceryList = ({
                 })}
             {isEditing && (
               <button
-                className="btn btn-icon btn-icon-success"
+                className="btn btn-icon btn-icon-green"
                 onClick={addNewItem}
                 aria-label={t("add_item")}
               >

--- a/src/pages/GroceryList/GroceryList.jsx
+++ b/src/pages/GroceryList/GroceryList.jsx
@@ -230,7 +230,7 @@ const GroceryList = ({
             onClick={() => navigate(-1)}
           />
         )}
-        <h1>{t("grocery_list")}</h1>
+        <h1 className="forta">{t("grocery_list")}</h1>
         {!isEditing && (
           <Pencil onClick={startEditing} className="btn btn-icon" />
         )}

--- a/src/pages/Recipe/Recipe.jsx
+++ b/src/pages/Recipe/Recipe.jsx
@@ -64,7 +64,7 @@ const Recipe = () => {
   return (
     <div className="recipe-container card card-recipe">
       <div className="flex-row">
-        <h1 className="forta">{recipe.title}</h1>
+        <h1 className="forta-red">{recipe.title}</h1>
 
         {/* Show edit button only when logged in  */}
         {isLoggedIn && !isGuest && (

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -50,6 +50,46 @@ export const forgotPassword = async (email) => {
   }
 };
 
+export const verifyCurrentPassword = async (currentPassword) => {
+  try {
+    // Get current user
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return { error: { message: "No authenticated user" } };
+    }
+
+    // Get user's email from database
+    const { data: userData, error: emailError } = await supabase
+      .from("users")
+      .select("email")
+      .eq("id", user.id)
+      .single();
+
+    if (emailError || !userData?.email) {
+      return { error: { message: "Could not retrieve user email" } };
+    }
+
+    // Try to sign in with current credentials to verify password
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email: userData.email,
+      password: currentPassword,
+    });
+
+    if (error) {
+      return { error: { message: "Current password is incorrect" } };
+    }
+
+    return { data, error: null };
+  } catch (err) {
+    console.error("Verify password service exception:", err);
+    return { error: err };
+  }
+};
+
 export const changePassword = async (new_password) => {
   try {
     // Check if user is authenticated

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -3,37 +3,41 @@ import supabase from "../lib/supabase";
 // Get user's preferred language from database
 export const getUserPreferredLanguage = async () => {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return 'en';
-    
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return "en";
+
     const { data: userData } = await supabase
-      .from('users')
-      .select('preferred_language')
-      .eq('id', user.id)
+      .from("users")
+      .select("preferred_language")
+      .eq("id", user.id)
       .single();
-      
-    return userData?.preferred_language || 'en';
+
+    return userData?.preferred_language || "en";
   } catch (error) {
-    console.error('Error fetching user preferred language:', error);
-    return 'en'; // Default fallback
+    console.error("Error fetching user preferred language:", error);
+    return "en"; // Default fallback
   }
 };
 
 // Update user's preferred language
 export const updateUserPreferredLanguage = async (language) => {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) throw new Error('User not authenticated');
-    
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new Error("User not authenticated");
+
     const { error } = await supabase
-      .from('users')
+      .from("users")
       .update({ preferred_language: language })
-      .eq('id', user.id);
-      
+      .eq("id", user.id);
+
     if (error) throw error;
     return true;
   } catch (error) {
-    console.error('Error updating user preferred language:', error);
+    console.error("Error updating user preferred language:", error);
     throw error;
   }
 };
@@ -41,19 +45,42 @@ export const updateUserPreferredLanguage = async (language) => {
 // Get user profile data
 export const getUserProfile = async () => {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     if (!user) return null;
-    
+
     const { data: profile, error } = await supabase
-      .from('users')
-      .select('*')
-      .eq('id', user.id)
+      .from("users")
+      .select("*")
+      .eq("id", user.id)
       .single();
-      
+
     if (error) throw error;
     return profile;
   } catch (error) {
-    console.error('Error fetching user profile:', error);
+    console.error("Error fetching user profile:", error);
     return null;
+  }
+};
+
+// Update user profile data
+export const updateUserProfile = async (updates) => {
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new Error("User not authenticated");
+
+    const { error } = await supabase
+      .from("users")
+      .update(updates)
+      .eq("id", user.id);
+
+    if (error) throw error;
+    return true;
+  } catch (error) {
+    console.error("Error updating user profile:", error);
+    throw error;
   }
 };

--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -93,7 +93,7 @@
   color: var(--dark-red);
 }
 
-.btn-icon-success {
+.btn-icon-green {
   color: var(--green);
 }
 
@@ -116,7 +116,7 @@
   right: 0.5rem;
 }
 
-.btn-icon-success:hover,
+.btn-icon-green:hover,
 .btn-icon-remove:hover,
 .btn-icon-red:hover {
   transform: translateY(-1px);

--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -137,6 +137,11 @@
   cursor: pointer;
 }
 
+.back-arrow-responsive {
+  left: 0;
+  position: absolute;
+}
+
 /* Add section buttons */
 .btn-section-dotted {
   padding: 0.375rem 0.75rem;
@@ -178,5 +183,11 @@
 
   .btn-section {
     padding: 0.375rem 0.625rem;
+  }
+
+  .back-arrow-responsive {
+    cursor: pointer;
+    padding-right: 0.5rem;
+    position: relative;
   }
 }

--- a/src/styles/components/inputs.css
+++ b/src/styles/components/inputs.css
@@ -35,7 +35,7 @@
 
 .input--edit {
   box-shadow: 0 0.0625rem 0.1rem var(--shadow-black);
-  border: var(--border-width) dashed var(--cream);
+  border: var(--border-width) dashed var(--lighter-brown);
 }
 
 .input--full-width {

--- a/src/styles/components/inputs.css
+++ b/src/styles/components/inputs.css
@@ -84,6 +84,124 @@
   margin: 0;
 }
 
+/* Input with Icon Styles */
+.input-with-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.input-with-icon input,
+.input-with-icon .relative-center {
+  width: 100%;
+}
+
+.input-with-icon svg {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--dark-brown);
+  z-index: 1;
+}
+
+/* All inputs inside input-with-icon container should have left padding for icon space */
+.input-with-icon input,
+.input--with-icon {
+  padding-left: 2.5rem;
+}
+
+/* Adjust PasswordInput when used with icons - needs right padding for eye icon */
+.input-with-icon .input--password {
+  padding-right: 2.5rem;
+}
+
+/* Fix eye icon positioning - override the general svg rule */
+.input-with-icon .btn-icon-password svg {
+  position: static;
+  left: auto;
+  z-index: auto;
+}
+
+/* Floating Label Inside Input */
+.floating-label-input {
+  position: relative;
+}
+
+.floating-label-input input {
+  padding: 1.2rem 0.75rem 0.5rem 0.75rem;
+  transition: all 0.2s ease;
+}
+
+.floating-label-input label {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: grey;
+  font-size: 1rem;
+  pointer-events: none;
+  transition: all 0.2s ease;
+  background: transparent;
+}
+
+.floating-label-input input:focus + label {
+  top: 0.25rem;
+  transform: translateY(0);
+  font-size: 0.75rem;
+  color: var(--dark-red) !important;
+}
+
+.floating-label-input input:not(:placeholder-shown) + label {
+  top: 0.25rem;
+  transform: translateY(0);
+  font-size: 0.75rem;
+  color: var(--dark-brown);
+}
+
+/* For PasswordInput: when input inside relative-center is focused/has content, target the label after relative-center */
+.floating-label-input .relative-center:has(input:focus) + label {
+  top: 0.25rem;
+  transform: translateY(0);
+  font-size: 0.75rem;
+  color: var(--dark-red) !important;
+}
+
+.floating-label-input
+  .relative-center:has(input:not(:placeholder-shown))
+  + label {
+  top: 0.25rem;
+  transform: translateY(0);
+  font-size: 0.75rem;
+  color: var(--dark-brown);
+}
+
+/* Adjust padding for PasswordInput in floating label */
+.floating-label-input .relative-center input {
+  padding: 1.2rem 2.5rem 0.5rem 0.75rem;
+}
+
+.floating-label-input input:focus {
+  border-color: var(--dark-red);
+}
+
+/* Floating Label with Icons - just positioning adjustments */
+.input-with-icon.floating-label-input label {
+  left: 2.5rem; /* Move label to the right of the icon */
+}
+
+.input-with-icon.floating-label-input input {
+  padding-left: 2.5rem; /* Ensure typed text starts after the icon */
+}
+
+.input-with-icon.floating-label-input input:focus + label,
+.input-with-icon.floating-label-input input:not(:placeholder-shown) + label,
+.input-with-icon.floating-label-input .relative-center:has(input:focus) + label,
+.input-with-icon.floating-label-input
+  .relative-center:has(input:not(:placeholder-shown))
+  + label {
+  left: 2.5rem; /* Keep label positioned after icon when floating */
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .input {

--- a/src/styles/components/inputs.css
+++ b/src/styles/components/inputs.css
@@ -7,7 +7,7 @@
   color: var(--dark-brown);
   background: white;
   border: var(--border-width) solid var(--dark-brown);
-  transition: all 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
   box-sizing: border-box;
   min-width: 0;
   word-break: break-word;

--- a/src/styles/globals/typography.css
+++ b/src/styles/globals/typography.css
@@ -52,9 +52,19 @@ h3 {
   font-size: 1.1rem;
 }
 
-h1.forta {
+h1.forta-red {
   font-family: var(--font-forta);
   color: var(--dark-red);
+}
+
+h1.forta {
+  font-family: var(--font-forta);
+  font-size: 1.8rem;
+}
+
+h1.forta-small {
+  font-family: var(--font-forta);
+  font-size: 1.1rem;
 }
 
 h2.forta {

--- a/src/styles/globals/variables.css
+++ b/src/styles/globals/variables.css
@@ -1,6 +1,7 @@
 :root {
   --cream: #f2e7d2;
   --cream-light: #fffbf4;
+  --cream-opaque: #fffbf4da;
   --lighter-brown: #523f1955;
   --light-brown: #523f19bf;
   --brown: #55443c;

--- a/src/styles/globals/variables.css
+++ b/src/styles/globals/variables.css
@@ -1,7 +1,7 @@
 :root {
   --cream: #f2e7d2;
   --cream-light: #fffbf4;
-  --cream-background: rgba(255, 249, 240, 0.8);
+  --lighter-brown: #523f1955;
   --light-brown: #523f19bf;
   --brown: #55443c;
   --dark-brown: #342a24;

--- a/src/styles/layout/containers.css
+++ b/src/styles/layout/containers.css
@@ -119,8 +119,20 @@
 .input-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
   min-width: 15rem;
+  align-items: flex-start;
+}
+
+.input-wrapper .input,
+.input-wrapper .relative-center {
+  width: 100%;
+  align-self: stretch;
+}
+
+/* Add spacing between field groups within input wrapper - apply to inputs/components instead of labels */
+.input-wrapper .input,
+.input-wrapper .relative-center {
+  margin-bottom: 0.25rem;
 }
 
 /* Subheading wrappers */

--- a/src/styles/layout/containers.css
+++ b/src/styles/layout/containers.css
@@ -1,6 +1,6 @@
 /* Cards */
 .card {
-  background: var(--cream-light);
+  background: var(--cream-opaque);
   border-radius: var(--border-radius);
   box-shadow: 0 0.25rem 0.375rem var(--shadow-black);
   overflow: hidden;

--- a/src/styles/layout/containers.css
+++ b/src/styles/layout/containers.css
@@ -83,12 +83,14 @@
   margin-bottom: 1rem;
 }
 
-.auth-form {
+.auth-form,
+.auth-container {
   display: flex;
   gap: 0.5rem;
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  position: relative;
 }
 
 .form-header {
@@ -119,20 +121,17 @@
 .input-wrapper {
   display: flex;
   flex-direction: column;
-  min-width: 15rem;
+  gap: 0.5rem;
   align-items: flex-start;
+  min-width: 18rem;
 }
 
-.input-wrapper .input,
-.input-wrapper .relative-center {
+.input-wrapper .input-with-icon {
   width: 100%;
-  align-self: stretch;
 }
 
-/* Add spacing between field groups within input wrapper - apply to inputs/components instead of labels */
-.input-wrapper .input,
-.input-wrapper .relative-center {
-  margin-bottom: 0.25rem;
+.input-wrapper .floating-label-input {
+  width: 100%;
 }
 
 /* Subheading wrappers */

--- a/src/styles/layout/containers.css
+++ b/src/styles/layout/containers.css
@@ -13,14 +13,12 @@
 }
 
 .card-grocery {
-  background: var(--cream-background);
   padding: 2rem 3rem;
   min-width: calc(0.3 * 100vw);
   max-width: -webkit-fill-available;
 }
 
 .card-form {
-  background: var(--cream-background);
   padding: 2rem 3rem;
   max-width: 50rem;
   width: -webkit-fill-available;

--- a/src/styles/layout/containers.css
+++ b/src/styles/layout/containers.css
@@ -61,6 +61,12 @@
   flex-direction: column;
 }
 
+.flex-column-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .flex-row {
   display: flex;
   align-items: center;
@@ -103,7 +109,7 @@
   padding-top: 1rem;
 }
 
-.btn-icon-success-wrapper {
+.btn-icon-green-wrapper {
   display: flex;
   justify-content: center;
   padding-top: 0.5rem;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -76,6 +76,11 @@ export const validateChangePasswordForm = (formData, t, requireOldPassword = fal
   const passwordError = validatePassword(newPassword, t);
   if (passwordError) errors.newPassword = passwordError;
 
+  // Check if new password is the same as old password
+  if (requireOldPassword && oldPassword && newPassword && oldPassword === newPassword) {
+    errors.newPassword = t("new_password_same_as_old");
+  }
+
   if (!newPasswordRepeat.trim()) {
     errors.newPasswordRepeat = t("password_repeat_required");
   } else if (newPassword !== newPasswordRepeat) {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -63,9 +63,15 @@ export const validateForgotPasswordForm = (email, t) => {
   return errors;
 };
 
-export const validateChangePasswordForm = (formData, t) => {
+export const validateChangePasswordForm = (formData, t, requireOldPassword = false) => {
   const errors = {};
-  const { newPassword, newPasswordRepeat } = formData;
+  const { oldPassword, newPassword, newPasswordRepeat } = formData;
+
+  // Validate old password if required (when coming from account settings)
+  if (requireOldPassword) {
+    const oldPasswordError = validatePassword(oldPassword, t);
+    if (oldPasswordError) errors.oldPassword = oldPasswordError;
+  }
 
   const passwordError = validatePassword(newPassword, t);
   if (passwordError) errors.newPassword = passwordError;

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -254,6 +254,60 @@ describe("Validation Utilities", () => {
       const errors = validateChangePasswordForm(formData, mockT);
       expect(errors.newPasswordRepeat).toBe("password_repeat_required");
     });
+
+    describe("with old password requirement", () => {
+      test("returns oldPassword error when old password is empty and required", () => {
+        const formData = {
+          oldPassword: "",
+          newPassword: "newpassword123",
+          newPasswordRepeat: "newpassword123",
+        };
+        const errors = validateChangePasswordForm(formData, mockT, true);
+        expect(errors.oldPassword).toBe("password_required");
+      });
+
+      test("returns error when new password is same as old password", () => {
+        const formData = {
+          oldPassword: "samepassword123",
+          newPassword: "samepassword123",
+          newPasswordRepeat: "samepassword123",
+        };
+        const errors = validateChangePasswordForm(formData, mockT, true);
+        expect(errors.newPassword).toBe("new_password_same_as_old");
+        expect(mockT).toHaveBeenCalledWith("new_password_same_as_old");
+      });
+
+      test("allows new password when different from old password", () => {
+        const formData = {
+          oldPassword: "oldpassword123",
+          newPassword: "newpassword123",
+          newPasswordRepeat: "newpassword123",
+        };
+        const errors = validateChangePasswordForm(formData, mockT, true);
+        expect(errors).toEqual({});
+      });
+
+      test("does not check password similarity when requireOldPassword is false", () => {
+        const formData = {
+          oldPassword: "samepassword123",
+          newPassword: "samepassword123",
+          newPasswordRepeat: "samepassword123",
+        };
+        const errors = validateChangePasswordForm(formData, mockT, false);
+        expect(errors.newPassword).toBeUndefined();
+      });
+
+      test("does not check password similarity when old password is empty", () => {
+        const formData = {
+          oldPassword: "",
+          newPassword: "password123",
+          newPasswordRepeat: "password123",
+        };
+        const errors = validateChangePasswordForm(formData, mockT, true);
+        expect(errors.oldPassword).toBe("password_required"); // Error is on oldPassword field
+        expect(errors.newPassword).toBeUndefined(); // No similarity check when oldPassword is empty
+      });
+    });
   });
 
   describe("validateRecipeTitle", () => {


### PR DESCRIPTION
- Add Account Settings page for user account editing
- Update Change Password page for logged in users to also change password (not yet working with backend)
- Add floating label display for authentication and password input boxes
- Add icons for authentication input boxes
- Add more Change Password validation test
- Minor CSS changes for headers, font and alignment 

<img width="200" alt="localhost_5173_account-settings(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/4b9cea95-f600-4e10-a1da-f4983633fd90" />
<img width="200" alt="localhost_5173_change-password(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/e928eeba-e998-4ecd-a7a5-70a24b6bf80e" />
<img width="200" alt="localhost_5173_account-settings(iPhone 12 Pro) (4)" src="https://github.com/user-attachments/assets/51b5aac0-58a6-4ad9-a76a-80df53f71da7" />
<img width="200" alt="localhost_5173_account-settings(iPhone 12 Pro) (3)" src="https://github.com/user-attachments/assets/f5f05966-e0a4-4052-850a-b33330ece91c" />
<img width="500" alt="localhost_5173_account-settings (1)" src="https://github.com/user-attachments/assets/46a6002f-f5d2-4483-a35b-4166c9540fb7" />

