### PR TITLE
Add delete account button and real-time recipe filtering.

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -152,6 +152,8 @@
   "title_required": "Rezepttitel ist erforderlich",
   "title_already_exists": "Ein Rezept mit diesem Titel existiert bereits",
   "category_required": "Kategorie ist erforderlich",
+  "recipe_create_error": "Rezept konnte nicht erstellt werden. Bitte erneut versuchen.",
+  "recipe_update_error": "Rezept konnte nicht aktualisiert werden. Bitte erneut versuchen.",
 
   "add_to_grocery_list": "zur Einkaufsliste hinzufügen",
   "added_to_groceries": "Zur Einkaufsliste hinzugefügt",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -74,7 +74,7 @@
   "delete_account": "Konto löschen",
   "delete_account_confirmation": "Möchten Sie Ihr Konto wirklich löschen?",
   "delete_account_warning": "Ich verstehe, dass dieser Vorgang nicht rückgängig gemacht werden kann und alle meine Rezepte gelöscht werden",
-  "account_deleted_message": "Ihr Konto wurde erfolgreich gelöscht",
+  "account_deleted_goodbye": "Auf Wiedersehen, {{name}}! Ihr Konto wurde erfolgreich gelöscht.",
   "delete_account_error": "Konto konnte nicht gelöscht werden. Bitte erneut versuchen.",
 
   "search": "Suchen",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -72,8 +72,10 @@
   "successfully_updated_first_name": "Vorname erfolgreich aktualisiert",
   "successfully_updated_language": "Bevorzugte Sprache erfolgreich aktualisiert",
   "delete_account": "Konto löschen",
-  "delete_account_message": "Möchten Sie Ihr Konto wirklich löschen? Dieser Vorgang kann nicht rückgängig gemacht werden. Alle Ihre Daten werden dauerhaft gelöscht.",
+  "delete_account_confirmation": "Möchten Sie Ihr Konto wirklich löschen?",
+  "delete_account_warning": "Ich verstehe, dass dieser Vorgang nicht rückgängig gemacht werden kann und alle meine Rezepte gelöscht werden",
   "account_deleted_message": "Ihr Konto wurde erfolgreich gelöscht",
+  "delete_account_error": "Konto konnte nicht gelöscht werden. Bitte erneut versuchen.",
 
   "search": "Suchen",
   "recipe_not_found": "Rezept nicht gefunden.",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -71,6 +71,9 @@
   "successfully_updated_username": "Benutzername erfolgreich aktualisiert",
   "successfully_updated_first_name": "Vorname erfolgreich aktualisiert",
   "successfully_updated_language": "Bevorzugte Sprache erfolgreich aktualisiert",
+  "delete_account": "Konto löschen",
+  "delete_account_message": "Möchten Sie Ihr Konto wirklich löschen? Dieser Vorgang kann nicht rückgängig gemacht werden. Alle Ihre Daten werden dauerhaft gelöscht.",
+  "account_deleted_message": "Ihr Konto wurde erfolgreich gelöscht",
 
   "search": "Suchen",
   "recipe_not_found": "Rezept nicht gefunden.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -74,7 +74,7 @@
   "delete_account": "Delete account",
   "delete_account_confirmation": "Are you sure you want to delete your account?",
   "delete_account_warning": "I understand this cannot be undone and all my recipes will be deleted",
-  "account_deleted_message": "Your account has been successfully deleted",
+  "account_deleted_goodbye": "Goodbye, {{name}}! Your account has been successfully deleted.",
   "delete_account_error": "Failed to delete account. Please try again.",
 
   "search": "Search",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -156,6 +156,8 @@
   "title_required": "Recipe title is required",
   "title_already_exists": "A recipe with this title already exists",
   "category_required": "Category is required",
+  "recipe_create_error": "Failed to create recipe. Please try again.",
+  "recipe_update_error": "Failed to update recipe. Please try again.",
 
   "add_to_grocery_list": "Add to grocery list",
   "added_to_groceries": "Added to grocery list",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -72,8 +72,10 @@
   "successfully_updated_first_name": "Successfully updated first name",
   "successfully_updated_language": "Successfully updated preferred language",
   "delete_account": "Delete account",
-  "delete_account_message": "Are you sure you want to delete your account? This action cannot be undone and all your recipes will be permanently removed.",
+  "delete_account_confirmation": "Are you sure you want to delete your account?",
+  "delete_account_warning": "I understand this cannot be undone and all my recipes will be deleted",
   "account_deleted_message": "Your account has been successfully deleted",
+  "delete_account_error": "Failed to delete account. Please try again.",
 
   "search": "Search",
   "recipe_not_found": "Recipe not found.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -61,7 +61,7 @@
   "current_password_incorrect": "Current password is incorrect",
   "password_min_length": "At least 8 characters",
   "password_lowercase": "Contains lowercase letter",
-  "password_uppercase": "Contains uppercase letter", 
+  "password_uppercase": "Contains uppercase letter",
   "password_digit": "Contains digit",
   "password_symbol": "Contains symbol",
   "password_requirements_not_met": "Password must meet all requirements",
@@ -71,6 +71,9 @@
   "successfully_updated_username": "Successfully updated username",
   "successfully_updated_first_name": "Successfully updated first name",
   "successfully_updated_language": "Successfully updated preferred language",
+  "delete_account": "Delete account",
+  "delete_account_message": "Are you sure you want to delete your account? This action cannot be undone and all your recipes will be permanently removed.",
+  "account_deleted_message": "Your account has been successfully deleted",
 
   "search": "Search",
   "recipe_not_found": "Recipe not found.",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -162,6 +162,7 @@ function AppRoutes(props) {
         setLanguage={props.setLanguage}
         setSelectedCategory={props.setSelectedCategory}
         setSearchTerm={props.setSearchTerm}
+        searchTerm={props.searchTerm}
         setLoginMessage={props.setLoginMessage}
         loginMessage={props.loginMessage}
         t={props.t}

--- a/src/components/ConfirmationModal/ConfirmationModal.jsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.jsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 const ConfirmationModal = ({
   isOpen,
   onClose,
@@ -7,7 +9,10 @@ const ConfirmationModal = ({
   confirmText = "Confirm",
   cancelText = "Cancel",
   confirmButtonType = "danger", // "danger" | "primary" | "secondary"
+  requireConfirmation = false,
+  confirmationText = "",
 }) => {
+  const [isConfirmed, setIsConfirmed] = useState(false);
   if (!isOpen) return null;
 
   const handleOverlayClick = (e) => {
@@ -16,17 +21,43 @@ const ConfirmationModal = ({
     }
   };
 
+  const handleClose = () => {
+    setIsConfirmed(false);
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    setIsConfirmed(false);
+    onConfirm();
+  };
+
   return (
     <div className="confirmation-modal-overlay" onClick={handleOverlayClick}>
       <div className="confirmation-modal-content">
         {title && <h3 className="confirmation-modal-title">{title}</h3>}
         <p className="confirmation-modal-message">{message}</p>
+        
+        {requireConfirmation && (
+          <div className="confirmation-checkbox-wrapper">
+            <label className="confirmation-checkbox-label">
+              <input
+                type="checkbox"
+                checked={isConfirmed}
+                onChange={(e) => setIsConfirmed(e.target.checked)}
+                className="confirmation-checkbox"
+              />
+              <span className="confirmation-checkbox-text">{confirmationText}</span>
+            </label>
+          </div>
+        )}
+        
         <div className="confirmation-modal-actions">
-          <button onClick={onClose} className="btn btn-action btn-secondary">
+          <button onClick={handleClose} className="btn btn-action btn-secondary">
             {cancelText}
           </button>
           <button
-            onClick={onConfirm}
+            onClick={handleConfirm}
+            disabled={requireConfirmation && !isConfirmed}
             className={`btn btn-action btn-${confirmButtonType}`}
           >
             {confirmText}

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -63,7 +63,7 @@
   font-size: 0.9rem;
   color: var(--dark-red);
   font-weight: 500;
-  margin-top: 0.25rem;
+  margin: 0.25rem;
   text-align: center;
 }
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -17,6 +17,7 @@ import "./Header.css";
 const Header = ({
   setSelectedCategory,
   setSearchTerm,
+  searchTerm,
   setLoginMessage,
   loginMessage,
   disableLanguageSwitch = false,
@@ -31,6 +32,7 @@ const Header = ({
 
   const [showNavMenu, setShowNavMenu] = useState(false);
   const [showUserDropdown, setShowUserDropdown] = useState(false);
+  const [currentSearchInput, setCurrentSearchInput] = useState("");
 
   // Language
   const { t, i18n } = useTranslation();
@@ -53,6 +55,11 @@ const Header = ({
       setFirstName("");
     }
   }, [isLoggedIn, setFirstName]);
+
+  // Sync search input with external search term changes
+  useEffect(() => {
+    setCurrentSearchInput(searchTerm || "");
+  }, [searchTerm]);
 
   // Refs for click outside detection
 
@@ -315,7 +322,7 @@ const Header = ({
               className="search-bar"
               onSubmit={(e) => {
                 e.preventDefault();
-                setSearchTerm(e.target.elements.search.value);
+                setSearchTerm(currentSearchInput);
                 navigate("/");
               }}
             >
@@ -323,6 +330,14 @@ const Header = ({
                 <input
                   id="search"
                   type="text"
+                  value={currentSearchInput}
+                  onChange={(e) => {
+                    setCurrentSearchInput(e.target.value);
+                    setSearchTerm(e.target.value);
+                    if (e.target.value.length > 0) {
+                      setSelectedCategory("all");
+                    }
+                  }}
                   className="input input--cream search-input-with-icon"
                   placeholder={t("search")}
                 />

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -122,7 +122,7 @@ const Header = ({
     <div className={"user-icon-wrapper"} ref={userDropdownRef}>
       <button
         className={`btn btn-icon btn-icon-neutral ${
-          showUserDropdown ? "selected" : ""
+          showUserDropdown || location.pathname === "/account-settings" ? "selected" : ""
         }`}
         onClick={() => {
           if (location.pathname === "/auth-page") return;
@@ -140,7 +140,9 @@ const Header = ({
             {isLoggedIn ? (
               <>
                 <button
-                  className="dropdown-item"
+                  className={`dropdown-item ${
+                    location.pathname === "/account-settings" ? "selected" : ""
+                  }`}
                   onClick={() => {
                     setShowUserDropdown(false);
                     navigate("/account-settings");

--- a/src/components/PasswordInput/PasswordInput.jsx
+++ b/src/components/PasswordInput/PasswordInput.jsx
@@ -32,7 +32,7 @@ const PasswordInput = ({
       <button
         type="button"
         onClick={togglePasswordVisibility}
-        className="btn btn-icon btn-icon-password"
+        className="btn btn-icon btn-icon-right"
         aria-label={showPassword ? t("hide_password") : t("show_password")}
       >
         {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}

--- a/src/components/RecipeForm/RecipeForm.jsx
+++ b/src/components/RecipeForm/RecipeForm.jsx
@@ -24,6 +24,7 @@ const RecipeForm = ({ categories, initialRecipe = null, title = "" }) => {
   const {
     formData,
     validationErrors,
+    submissionError,
     loading,
     // error,
     isEditMode,
@@ -95,6 +96,11 @@ const RecipeForm = ({ categories, initialRecipe = null, title = "" }) => {
         />
         <h1 className="forta">{title}</h1>
       </header>
+
+      {/* Submission Error Message */}
+      {submissionError && (
+        <div className="error-message submission-error">{submissionError}</div>
+      )}
 
       <form onSubmit={handleSubmit} className="recipe-form" role="form">
         {/* Recipe Title and Servings */}

--- a/src/hooks/forms/useRecipeForm.js
+++ b/src/hooks/forms/useRecipeForm.js
@@ -138,6 +138,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
 
   const [formData, setFormData] = useState(getInitialFormData);
   const [validationErrors, setValidationErrors] = useState({});
+  const [submissionError, setSubmissionError] = useState("");
 
   // Update form data when initialRecipe changes (for edit mode)
   useEffect(() => {
@@ -567,6 +568,9 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
+    // Clear any previous submission error
+    setSubmissionError("");
+
     if (!(await handleValidation())) {
       window.scrollTo(0, 0);
       return;
@@ -638,6 +642,15 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
         `Failed to ${initialRecipe ? "update" : "create"} recipe:`,
         err
       );
+
+      // Set user-friendly error message
+      const errorKey = initialRecipe
+        ? "recipe_update_error"
+        : "recipe_create_error";
+      setSubmissionError(t(errorKey));
+
+      // Scroll to top to show the error message
+      window.scrollTo(0, 0);
     }
   };
 
@@ -659,6 +672,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
   return {
     formData,
     validationErrors,
+    submissionError,
     loading,
     error,
     isEditMode: !!initialRecipe,

--- a/src/hooks/forms/useRecipeForm.js
+++ b/src/hooks/forms/useRecipeForm.js
@@ -14,6 +14,11 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
   const { createRecipe, updateRecipe, deleteRecipe, loading, error } =
     useRecipeActions();
 
+  // Generate unique IDs for ingredients
+  const generateUniqueId = () => {
+    return `temp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  };
+
   const getInitialFormData = useCallback(() => {
     if (initialRecipe) {
       // Handle ungrouped ingredients and sections separately
@@ -27,7 +32,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
         // New structure with separated ungrouped and grouped ingredients
         ungroupedIngredients = (initialRecipe.ungroupedIngredients || []).map(
           (ing) => ({
-            tempId: ing.id || Date.now() + Math.random(),
+            tempId: generateUniqueId(),
             ingredient_id: ing.ingredient_id || "",
             name: ing.name || ing.singular_name || "",
             quantity: ing.quantity || "",
@@ -41,7 +46,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
             id: section.id || `section-${index}`,
             subheading: section.subheading || "",
             ingredients: section.ingredients.map((ing) => ({
-              tempId: ing.id || Date.now() + Math.random(),
+              tempId: generateUniqueId(),
               ingredient_id: ing.ingredient_id || "",
               name: ing.name || ing.singular_name || "",
               quantity: ing.quantity || "",
@@ -54,7 +59,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
         // Convert flat ingredient list: separate ungrouped from grouped
         initialRecipe.ingredients.forEach((ing) => {
           const ingredient = {
-            tempId: ing.id || Date.now() + Math.random(),
+            tempId: generateUniqueId(),
             ingredient_id: ing.ingredient_id || "",
             name: ing.name || ing.singular_name || "",
             quantity: ing.quantity || "",
@@ -89,7 +94,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
       ) {
         ungroupedIngredients = [
           {
-            tempId: Date.now() + Math.random(),
+            tempId: generateUniqueId(),
             ingredient_id: "",
             name: "",
             quantity: "",
@@ -122,7 +127,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
       source: "",
       ungroupedIngredients: [
         {
-          tempId: Date.now() + Math.random(),
+          tempId: generateUniqueId(),
           ingredient_id: "",
           name: "",
           quantity: "",
@@ -266,7 +271,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
   };
 
   const addIngredient = (sectionId) => {
-    const newTempId = Date.now() + Math.random();
+    const newTempId = generateUniqueId();
 
     if (sectionId === "ungrouped") {
       // Add to ungrouped ingredients
@@ -322,7 +327,7 @@ export const useRecipeForm = ({ initialRecipe = null }) => {
 
   const addSection = () => {
     const newSectionId = `section-${Date.now()}`;
-    const newTempId = Date.now() + Math.random();
+    const newTempId = generateUniqueId();
 
     setFormData((prev) => ({
       ...prev,

--- a/src/pages/AccountSettings/AccountSettings.css
+++ b/src/pages/AccountSettings/AccountSettings.css
@@ -1,7 +1,7 @@
 .acc-settings {
   display: flex;
   flex-direction: row;
-  gap: 2rem;
+  gap: 1rem;
 }
 
 .acc-settings-column {
@@ -28,6 +28,12 @@
 .acc-settings-actions {
   display: flex;
   gap: 0.5rem;
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0.25rem;
+  z-index: var(--z-content);
 }
 
 /* Override input focus border color */
@@ -45,14 +51,58 @@
   position: absolute;
   top: 100%;
   left: 0.25rem;
-  z-index: 1;
+  z-index: var(--z-content);
+}
+
+/* Account settings specific input styling */
+.acc-settings .floating-label-input input {
+  padding-right: 2.5rem;
+}
+
+/* Check icon positioning (left of X icon) */
+.acc-settings-check {
+  position: absolute;
+  right: 2rem;
+}
+
+/* X icon positioning (rightmost) */
+.acc-settings-cancel {
+  position: absolute;
+  right: 0.5rem;
+}
+
+/* Language section container */
+.acc-settings-language-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  width: 12rem;
+}
+
+/* Language actions positioned on far right when editing */
+.acc-settings-language-container .acc-settings-language-actions {
+  position: absolute;
+  right: 0;
+}
+
+/* Account settings container with proper spacing */
+.acc-settings-container {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  position: relative;
 }
 
 /* Mobile: Stack everything vertically */
 @media (max-width: 768px) {
   .acc-settings {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
   }
 
   .acc-settings-language .language-wrapper {

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -249,13 +249,13 @@ const AccountSettings = () => {
         <>
           <div className="card card-settings">
             <header className="flex-column-center">
-              <ArrowBigLeft
-                className="back-arrow-responsive"
-                onClick={() => navigate(-1)}
-              />
-              <h1 className="forta-small">
-                {t("account_settings").toUpperCase()}
-              </h1>
+              <div className="flex-row">
+                <ArrowBigLeft
+                  className="back-arrow-responsive"
+                  onClick={() => navigate(-1)}
+                />
+                <h1 className="forta-small">{t("account_settings")}</h1>
+              </div>
               <span className="login-message">
                 {successMessage || "\u00A0"}
               </span>
@@ -264,7 +264,10 @@ const AccountSettings = () => {
             <div className="acc-settings-container">
               <div className="acc-settings">
                 <div className="acc-settings-column">
-                  <div className="input-validation-wrapper" ref={firstNameContainerRef}>
+                  <div
+                    className="input-validation-wrapper"
+                    ref={firstNameContainerRef}
+                  >
                     <div className="floating-label-input">
                       <div className="relative-center">
                         <input
@@ -418,7 +421,10 @@ const AccountSettings = () => {
                   {t("preferred_language").toUpperCase()}
                 </h2>
 
-                <div className="acc-settings-language-container" ref={languageContainerRef}>
+                <div
+                  className="acc-settings-language-container"
+                  ref={languageContainerRef}
+                >
                   {!isEditingLanguage ? (
                     <div className="language-wrapper">
                       <span

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -175,9 +175,7 @@ const AccountSettings = () => {
       sessionStorage.clear();
     } catch (err) {
       console.error("Failed to delete account:", err);
-      setError(
-        t("delete_account_error", "Failed to delete account. Please try again.")
-      );
+      setError(t("delete_account_error"));
       setShowDeleteModal(false);
       setLoading(false);
     }
@@ -196,7 +194,7 @@ const AccountSettings = () => {
     <div className="page-centered">
       {showDeleteSuccess ? (
         <div className="flex-column-center">
-          <h2>{t("account_deleted_message")}</h2>
+          <span>{t("account_deleted_message")}</span>
           <strong>{deletedAccountInfo?.firstName}</strong>
         </div>
       ) : (
@@ -452,11 +450,12 @@ const AccountSettings = () => {
             isOpen={showDeleteModal}
             onClose={handleCancelDelete}
             onConfirm={handleConfirmDelete}
-            title={t("delete_account")}
-            message={t("delete_account_message")}
+            message={t("delete_account_confirmation")}
             confirmText={t("delete")}
             cancelText={t("cancel")}
             confirmButtonType="danger"
+            requireConfirmation={true}
+            confirmationText={t("delete_account_warning")}
           />
         </>
       )}

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -194,8 +194,11 @@ const AccountSettings = () => {
     <div className="page-centered">
       {showDeleteSuccess ? (
         <div className="flex-column-center">
-          <span>{t("account_deleted_message")}</span>
-          <strong>{deletedAccountInfo?.firstName}</strong>
+          <span>
+            {t("account_deleted_goodbye", {
+              name: deletedAccountInfo?.firstName,
+            })}
+          </span>
         </div>
       ) : (
         <>

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -31,6 +31,9 @@ const AccountSettings = () => {
   const [deletedAccountInfo, setDeletedAccountInfo] = useState(null);
   const usernameInputRef = useRef(null);
   const firstNameInputRef = useRef(null);
+  const usernameContainerRef = useRef(null);
+  const firstNameContainerRef = useRef(null);
+  const languageContainerRef = useRef(null);
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
 
@@ -56,6 +59,48 @@ const AccountSettings = () => {
 
     loadProfile();
   }, []);
+
+  // Handle click outside to cancel editing
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      // Check if click is outside username editing area
+      if (
+        isEditingUsername &&
+        usernameContainerRef.current &&
+        !usernameContainerRef.current.contains(event.target)
+      ) {
+        handleCancelUsername();
+      }
+
+      // Check if click is outside first name editing area
+      if (
+        isEditingFirstName &&
+        firstNameContainerRef.current &&
+        !firstNameContainerRef.current.contains(event.target)
+      ) {
+        handleCancelFirstName();
+      }
+
+      // Check if click is outside language editing area
+      if (
+        isEditingLanguage &&
+        languageContainerRef.current &&
+        !languageContainerRef.current.contains(event.target)
+      ) {
+        handleCancelLanguage();
+      }
+    };
+
+    // Add event listener if any editing is active
+    if (isEditingUsername || isEditingFirstName || isEditingLanguage) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    // Cleanup event listener
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isEditingUsername, isEditingFirstName, isEditingLanguage]);
 
   const handleEditUsername = () => {
     setTempUsername(profileData.username);
@@ -219,7 +264,7 @@ const AccountSettings = () => {
             <div className="acc-settings-container">
               <div className="acc-settings">
                 <div className="acc-settings-column">
-                  <div className="input-validation-wrapper">
+                  <div className="input-validation-wrapper" ref={firstNameContainerRef}>
                     <div className="floating-label-input">
                       <div className="relative-center">
                         <input
@@ -288,6 +333,7 @@ const AccountSettings = () => {
                   <div
                     className="input-validation-wrapper"
                     style={{ position: "relative" }}
+                    ref={usernameContainerRef}
                   >
                     <div className="floating-label-input">
                       <div className="relative-center">
@@ -372,7 +418,7 @@ const AccountSettings = () => {
                   {t("preferred_language").toUpperCase()}
                 </h2>
 
-                <div className="acc-settings-language-container">
+                <div className="acc-settings-language-container" ref={languageContainerRef}>
                   {!isEditingLanguage ? (
                     <div className="language-wrapper">
                       <span

--- a/src/pages/AccountSettings/AccountSettings.test.jsx
+++ b/src/pages/AccountSettings/AccountSettings.test.jsx
@@ -30,29 +30,29 @@ vi.mock("../../components/LoadingAcorn/LoadingAcorn", () => ({
 }));
 
 vi.mock("../../components/ConfirmationModal/ConfirmationModal", () => ({
-  default: ({ 
-    isOpen, 
-    onClose, 
-    onConfirm, 
-    title, 
-    message, 
-    confirmText, 
-    cancelText, 
-    requireConfirmation, 
-    confirmationText 
+  default: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    title,
+    message,
+    confirmText,
+    cancelText,
+    requireConfirmation,
+    confirmationText,
   }) => {
     const [isConfirmed, setIsConfirmed] = useState(false);
-    
+
     if (!isOpen) return null;
-    
+
     return (
       <div data-testid="confirmation-modal">
         <h3>{title}</h3>
         <p>{message}</p>
         {requireConfirmation && (
           <label>
-            <input 
-              type="checkbox" 
+            <input
+              type="checkbox"
               data-testid="confirmation-checkbox"
               checked={isConfirmed}
               onChange={(e) => setIsConfirmed(e.target.checked)}
@@ -60,9 +60,11 @@ vi.mock("../../components/ConfirmationModal/ConfirmationModal", () => ({
             {confirmationText}
           </label>
         )}
-        <button onClick={onClose} data-testid="modal-cancel">{cancelText}</button>
-        <button 
-          onClick={onConfirm} 
+        <button onClick={onClose} data-testid="modal-cancel">
+          {cancelText}
+        </button>
+        <button
+          onClick={onConfirm}
           data-testid="modal-confirm"
           disabled={requireConfirmation && !isConfirmed}
         >
@@ -142,13 +144,13 @@ describe("AccountSettings", () => {
     mockCheckUsernameExists.mockResolvedValue(false);
 
     // Mock localStorage and sessionStorage
-    Object.defineProperty(window, 'localStorage', {
+    Object.defineProperty(window, "localStorage", {
       value: {
         clear: vi.fn(),
       },
       writable: true,
     });
-    Object.defineProperty(window, 'sessionStorage', {
+    Object.defineProperty(window, "sessionStorage", {
       value: {
         clear: vi.fn(),
       },
@@ -185,10 +187,12 @@ describe("AccountSettings", () => {
       render(<AccountSettingsWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByText("ACCOUNT_SETTINGS")).toBeInTheDocument();
+        expect(screen.getByText("account_settings")).toBeInTheDocument();
         expect(screen.getByDisplayValue("John")).toBeInTheDocument();
         expect(screen.getByDisplayValue("johndoe")).toBeInTheDocument();
-        expect(screen.getByDisplayValue("john@example.com")).toBeInTheDocument();
+        expect(
+          screen.getByDisplayValue("john@example.com")
+        ).toBeInTheDocument();
       });
     });
 
@@ -196,10 +200,12 @@ describe("AccountSettings", () => {
       render(<AccountSettingsWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByText("ACCOUNT_SETTINGS")).toBeInTheDocument();
+        expect(screen.getByText("account_settings")).toBeInTheDocument();
       });
 
-      const backArrow = screen.getByRole("banner").querySelector('.back-arrow-responsive');
+      const backArrow = screen
+        .getByRole("banner")
+        .querySelector(".back-arrow-responsive");
       fireEvent.click(backArrow);
 
       expect(mockNavigate).toHaveBeenCalledWith(-1);
@@ -218,8 +224,10 @@ describe("AccountSettings", () => {
       const firstNameInput = screen.getByDisplayValue("John");
       expect(firstNameInput).toHaveAttribute("readonly");
 
-      const firstNameContainer = firstNameInput.closest('.floating-label-input');
-      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      const firstNameContainer = firstNameInput.closest(
+        ".floating-label-input"
+      );
+      const pencilIcon = firstNameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       expect(firstNameInput).not.toHaveAttribute("readonly");
@@ -228,40 +236,58 @@ describe("AccountSettings", () => {
 
     it("shows check and cancel buttons when editing", () => {
       const firstNameInput = screen.getByDisplayValue("John");
-      const firstNameContainer = firstNameInput.closest('.floating-label-input');
-      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      const firstNameContainer = firstNameInput.closest(
+        ".floating-label-input"
+      );
+      const pencilIcon = firstNameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
-      expect(firstNameContainer.querySelector('.acc-settings-check')).toBeInTheDocument();
-      expect(firstNameContainer.querySelector('.acc-settings-cancel')).toBeInTheDocument();
+      expect(
+        firstNameContainer.querySelector(".acc-settings-check")
+      ).toBeInTheDocument();
+      expect(
+        firstNameContainer.querySelector(".acc-settings-cancel")
+      ).toBeInTheDocument();
     });
 
     it("updates first name successfully", async () => {
       const firstNameInput = screen.getByDisplayValue("John");
-      const firstNameContainer = firstNameInput.closest('.floating-label-input');
-      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      const firstNameContainer = firstNameInput.closest(
+        ".floating-label-input"
+      );
+      const pencilIcon = firstNameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       fireEvent.change(firstNameInput, { target: { value: "Jane" } });
 
-      const checkButton = firstNameContainer.querySelector('.acc-settings-check');
+      const checkButton = firstNameContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {
-        expect(mockUpdateUserProfile).toHaveBeenCalledWith({ first_name: "Jane" });
-        expect(screen.getByText("successfully_updated_first_name")).toBeInTheDocument();
+        expect(mockUpdateUserProfile).toHaveBeenCalledWith({
+          first_name: "Jane",
+        });
+        expect(
+          screen.getByText("successfully_updated_first_name")
+        ).toBeInTheDocument();
       });
     });
 
     it("cancels editing when cancel button is clicked", () => {
       const firstNameInput = screen.getByDisplayValue("John");
-      const firstNameContainer = firstNameInput.closest('.floating-label-input');
-      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      const firstNameContainer = firstNameInput.closest(
+        ".floating-label-input"
+      );
+      const pencilIcon = firstNameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       fireEvent.change(firstNameInput, { target: { value: "Jane" } });
 
-      const cancelButton = firstNameContainer.querySelector('.acc-settings-cancel');
+      const cancelButton = firstNameContainer.querySelector(
+        ".acc-settings-cancel"
+      );
       fireEvent.click(cancelButton);
 
       expect(firstNameInput).toHaveValue("John");
@@ -281,8 +307,8 @@ describe("AccountSettings", () => {
       const usernameInput = screen.getByDisplayValue("johndoe");
       expect(usernameInput).toHaveAttribute("readonly");
 
-      const usernameContainer = usernameInput.closest('.floating-label-input');
-      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      const usernameContainer = usernameInput.closest(".floating-label-input");
+      const pencilIcon = usernameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       expect(usernameInput).not.toHaveAttribute("readonly");
@@ -290,19 +316,25 @@ describe("AccountSettings", () => {
 
     it("updates username successfully", async () => {
       const usernameInput = screen.getByDisplayValue("johndoe");
-      const usernameContainer = usernameInput.closest('.floating-label-input');
-      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      const usernameContainer = usernameInput.closest(".floating-label-input");
+      const pencilIcon = usernameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       fireEvent.change(usernameInput, { target: { value: "newusername" } });
 
-      const checkButton = usernameContainer.querySelector('.acc-settings-check');
+      const checkButton = usernameContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {
         expect(mockCheckUsernameExists).toHaveBeenCalledWith("newusername");
-        expect(mockUpdateUserProfile).toHaveBeenCalledWith({ username: "newusername" });
-        expect(screen.getByText("successfully_updated_username")).toBeInTheDocument();
+        expect(mockUpdateUserProfile).toHaveBeenCalledWith({
+          username: "newusername",
+        });
+        expect(
+          screen.getByText("successfully_updated_username")
+        ).toBeInTheDocument();
       });
     });
 
@@ -310,13 +342,15 @@ describe("AccountSettings", () => {
       mockCheckUsernameExists.mockResolvedValue(true);
 
       const usernameInput = screen.getByDisplayValue("johndoe");
-      const usernameContainer = usernameInput.closest('.floating-label-input');
-      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      const usernameContainer = usernameInput.closest(".floating-label-input");
+      const pencilIcon = usernameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       fireEvent.change(usernameInput, { target: { value: "existinguser" } });
 
-      const checkButton = usernameContainer.querySelector('.acc-settings-check');
+      const checkButton = usernameContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {
@@ -330,13 +364,15 @@ describe("AccountSettings", () => {
       mockCheckUsernameExists.mockResolvedValue(true);
 
       const usernameInput = screen.getByDisplayValue("johndoe");
-      const usernameContainer = usernameInput.closest('.floating-label-input');
-      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      const usernameContainer = usernameInput.closest(".floating-label-input");
+      const pencilIcon = usernameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       fireEvent.change(usernameInput, { target: { value: "existinguser" } });
 
-      const checkButton = usernameContainer.querySelector('.acc-settings-check');
+      const checkButton = usernameContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {
@@ -346,7 +382,9 @@ describe("AccountSettings", () => {
       // Clear error by typing
       fireEvent.change(usernameInput, { target: { value: "newuser" } });
 
-      expect(screen.queryByText("username_already_exists")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("username_already_exists")
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -369,12 +407,12 @@ describe("AccountSettings", () => {
       });
 
       const passwordInput = screen.getByDisplayValue("**************");
-      const passwordContainer = passwordInput.closest('.floating-label-input');
-      const pencilIcon = passwordContainer.querySelector('.btn-icon-right');
+      const passwordContainer = passwordInput.closest(".floating-label-input");
+      const pencilIcon = passwordContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
-      expect(mockNavigate).toHaveBeenCalledWith("/change-password", { 
-        state: { fromAccountSettings: true } 
+      expect(mockNavigate).toHaveBeenCalledWith("/change-password", {
+        state: { fromAccountSettings: true },
       });
     });
   });
@@ -390,15 +428,17 @@ describe("AccountSettings", () => {
     it("displays current language selection", () => {
       expect(screen.getByText("EN")).toBeInTheDocument();
       expect(screen.getByText("DE")).toBeInTheDocument();
-      
+
       // EN should be selected by default (mocked to return "en")
       const enSpan = screen.getByText("EN");
       expect(enSpan.className).toContain("selected");
     });
 
     it("enables language editing when pencil is clicked", () => {
-      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
-      const pencilIcon = languageContainer.querySelector('.btn');
+      const languageContainer = screen
+        .getByText("EN")
+        .closest(".acc-settings-language-container");
+      const pencilIcon = languageContainer.querySelector(".btn");
       fireEvent.click(pencilIcon);
 
       // Language options should become clickable
@@ -409,8 +449,10 @@ describe("AccountSettings", () => {
     });
 
     it("updates language preference successfully", async () => {
-      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
-      const pencilIcon = languageContainer.querySelector('.btn');
+      const languageContainer = screen
+        .getByText("EN")
+        .closest(".acc-settings-language-container");
+      const pencilIcon = languageContainer.querySelector(".btn");
       fireEvent.click(pencilIcon);
 
       // Click on DE option
@@ -418,19 +460,25 @@ describe("AccountSettings", () => {
       fireEvent.click(deOption);
 
       // Click check button
-      const checkButton = languageContainer.querySelector('.acc-settings-check');
+      const checkButton = languageContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {
         expect(mockUpdateUserPreferredLanguage).toHaveBeenCalledWith("de");
         expect(mockChangeLanguage).toHaveBeenCalledWith("de");
-        expect(screen.getByText("successfully_updated_language")).toBeInTheDocument();
+        expect(
+          screen.getByText("successfully_updated_language")
+        ).toBeInTheDocument();
       });
     });
 
     it("cancels language editing", () => {
-      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
-      const pencilIcon = languageContainer.querySelector('.btn');
+      const languageContainer = screen
+        .getByText("EN")
+        .closest(".acc-settings-language-container");
+      const pencilIcon = languageContainer.querySelector(".btn");
       fireEvent.click(pencilIcon);
 
       // Click on DE option
@@ -438,12 +486,16 @@ describe("AccountSettings", () => {
       fireEvent.click(deOption);
 
       // Click cancel button
-      const cancelButton = languageContainer.querySelector('.acc-settings-cancel');
+      const cancelButton = languageContainer.querySelector(
+        ".acc-settings-cancel"
+      );
       fireEvent.click(cancelButton);
 
       // Should return to non-editing state - pencil icon should be back
-      expect(languageContainer.querySelector('.acc-settings-cancel')).not.toBeInTheDocument();
-      expect(languageContainer.querySelector('.btn')).toBeInTheDocument();
+      expect(
+        languageContainer.querySelector(".acc-settings-cancel")
+      ).not.toBeInTheDocument();
+      expect(languageContainer.querySelector(".btn")).toBeInTheDocument();
     });
   });
 
@@ -451,12 +503,16 @@ describe("AccountSettings", () => {
     beforeEach(async () => {
       render(<AccountSettingsWrapper />);
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "delete_account" })).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: "delete_account" })
+        ).toBeInTheDocument();
       });
     });
 
     it("renders delete account button", () => {
-      expect(screen.getByRole("button", { name: "delete_account" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "delete_account" })
+      ).toBeInTheDocument();
     });
 
     it("opens confirmation modal when delete button is clicked", () => {
@@ -464,7 +520,9 @@ describe("AccountSettings", () => {
 
       expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
       expect(screen.getByText("delete_account")).toBeInTheDocument();
-      expect(screen.getByText("delete_account_confirmation")).toBeInTheDocument();
+      expect(
+        screen.getByText("delete_account_confirmation")
+      ).toBeInTheDocument();
     });
 
     it("displays confirmation checkbox with warning text", () => {
@@ -500,7 +558,9 @@ describe("AccountSettings", () => {
       fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
       fireEvent.click(screen.getByTestId("modal-cancel"));
 
-      expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("confirmation-modal")
+      ).not.toBeInTheDocument();
     });
 
     it("calls deleteUserAccount when confirmed", async () => {
@@ -523,10 +583,14 @@ describe("AccountSettings", () => {
       fireEvent.click(screen.getByTestId("modal-confirm"));
 
       await waitFor(() => {
-        expect(screen.getByText("account_deleted_goodbye_John")).toBeInTheDocument();
+        expect(
+          screen.getByText("account_deleted_goodbye_John")
+        ).toBeInTheDocument();
       });
 
-      expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("confirmation-modal")
+      ).not.toBeInTheDocument();
     });
 
     it("clears localStorage and sessionStorage after successful deletion", async () => {
@@ -554,8 +618,12 @@ describe("AccountSettings", () => {
         expect(screen.getByText(/delete_account_error/)).toBeInTheDocument();
       });
 
-      expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
-      expect(screen.queryByText("account_deleted_goodbye_John")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("confirmation-modal")
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("account_deleted_goodbye_John")
+      ).not.toBeInTheDocument();
     });
 
     it("handles deletion error and keeps user on page", async () => {
@@ -570,7 +638,9 @@ describe("AccountSettings", () => {
       });
 
       // After error, the full form is no longer displayed - just the error message
-      expect(screen.queryByRole("button", { name: "delete_account" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "delete_account" })
+      ).not.toBeInTheDocument();
       expect(window.localStorage.clear).not.toHaveBeenCalled();
       expect(window.sessionStorage.clear).not.toHaveBeenCalled();
     });
@@ -586,22 +656,32 @@ describe("AccountSettings", () => {
 
       // Trigger a successful update
       const firstNameInput = screen.getByDisplayValue("John");
-      const firstNameContainer = firstNameInput.closest('.floating-label-input');
-      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      const firstNameContainer = firstNameInput.closest(
+        ".floating-label-input"
+      );
+      const pencilIcon = firstNameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       fireEvent.change(firstNameInput, { target: { value: "Jane" } });
 
-      const checkButton = firstNameContainer.querySelector('.acc-settings-check');
+      const checkButton = firstNameContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {
-        expect(screen.getByText("successfully_updated_first_name")).toBeInTheDocument();
+        expect(
+          screen.getByText("successfully_updated_first_name")
+        ).toBeInTheDocument();
       });
 
       // Success message should be visible in the header
-      const header = screen.getByRole("banner") || screen.getByText("successfully_updated_first_name").closest("header");
-      expect(header).toContainElement(screen.getByText("successfully_updated_first_name"));
+      const header =
+        screen.getByRole("banner") ||
+        screen.getByText("successfully_updated_first_name").closest("header");
+      expect(header).toContainElement(
+        screen.getByText("successfully_updated_first_name")
+      );
     });
   });
 
@@ -616,13 +696,17 @@ describe("AccountSettings", () => {
       });
 
       const firstNameInput = screen.getByDisplayValue("John");
-      const firstNameContainer = firstNameInput.closest('.floating-label-input');
-      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      const firstNameContainer = firstNameInput.closest(
+        ".floating-label-input"
+      );
+      const pencilIcon = firstNameContainer.querySelector(".btn-icon-right");
       fireEvent.click(pencilIcon);
 
       fireEvent.change(firstNameInput, { target: { value: "Jane" } });
 
-      const checkButton = firstNameContainer.querySelector('.acc-settings-check');
+      const checkButton = firstNameContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {
@@ -631,7 +715,9 @@ describe("AccountSettings", () => {
     });
 
     it("handles language update errors", async () => {
-      mockUpdateUserPreferredLanguage.mockRejectedValue(new Error("Language service error"));
+      mockUpdateUserPreferredLanguage.mockRejectedValue(
+        new Error("Language service error")
+      );
 
       render(<AccountSettingsWrapper />);
 
@@ -639,14 +725,18 @@ describe("AccountSettings", () => {
         expect(screen.getByText("PREFERRED_LANGUAGE")).toBeInTheDocument();
       });
 
-      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
-      const pencilIcon = languageContainer.querySelector('.btn');
+      const languageContainer = screen
+        .getByText("EN")
+        .closest(".acc-settings-language-container");
+      const pencilIcon = languageContainer.querySelector(".btn");
       fireEvent.click(pencilIcon);
 
       const deOption = screen.getByText("DE");
       fireEvent.click(deOption);
 
-      const checkButton = languageContainer.querySelector('.acc-settings-check');
+      const checkButton = languageContainer.querySelector(
+        ".acc-settings-check"
+      );
       fireEvent.click(checkButton);
 
       await waitFor(() => {

--- a/src/pages/AccountSettings/AccountSettings.test.jsx
+++ b/src/pages/AccountSettings/AccountSettings.test.jsx
@@ -1,0 +1,657 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { useState } from "react";
+import AccountSettings from "./AccountSettings";
+
+// Create mock functions
+const mockNavigate = vi.fn();
+
+// Mock dependencies
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("../../services/userService", () => ({
+  getUserPreferredLanguage: vi.fn(),
+  updateUserPreferredLanguage: vi.fn(),
+  getUserProfile: vi.fn(),
+  updateUserProfile: vi.fn(),
+  checkUsernameExists: vi.fn(),
+  deleteUserAccount: vi.fn(),
+}));
+
+vi.mock("../../components/LoadingAcorn/LoadingAcorn", () => ({
+  default: () => <div data-testid="loading-acorn">Loading...</div>,
+}));
+
+vi.mock("../../components/ConfirmationModal/ConfirmationModal", () => ({
+  default: ({ 
+    isOpen, 
+    onClose, 
+    onConfirm, 
+    title, 
+    message, 
+    confirmText, 
+    cancelText, 
+    requireConfirmation, 
+    confirmationText 
+  }) => {
+    const [isConfirmed, setIsConfirmed] = useState(false);
+    
+    if (!isOpen) return null;
+    
+    return (
+      <div data-testid="confirmation-modal">
+        <h3>{title}</h3>
+        <p>{message}</p>
+        {requireConfirmation && (
+          <label>
+            <input 
+              type="checkbox" 
+              data-testid="confirmation-checkbox"
+              checked={isConfirmed}
+              onChange={(e) => setIsConfirmed(e.target.checked)}
+            />
+            {confirmationText}
+          </label>
+        )}
+        <button onClick={onClose} data-testid="modal-cancel">{cancelText}</button>
+        <button 
+          onClick={onConfirm} 
+          data-testid="modal-confirm"
+          disabled={requireConfirmation && !isConfirmed}
+        >
+          {confirmText}
+        </button>
+      </div>
+    );
+  },
+}));
+
+const mockChangeLanguage = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key, options) => {
+      if (key === "account_deleted_goodbye" && options?.name) {
+        return `account_deleted_goodbye_${options.name}`;
+      }
+      if (options && options.name) {
+        return `${key}_${options.name}`;
+      }
+      return key;
+    },
+    i18n: {
+      changeLanguage: mockChangeLanguage,
+    },
+  }),
+}));
+
+// Wrapper component for router context
+const AccountSettingsWrapper = () => (
+  <BrowserRouter>
+    <AccountSettings />
+  </BrowserRouter>
+);
+
+describe("AccountSettings", () => {
+  let mockGetUserProfile;
+  let mockGetUserPreferredLanguage;
+  let mockUpdateUserProfile;
+  let mockUpdateUserPreferredLanguage;
+  let mockCheckUsernameExists;
+  let mockDeleteUserAccount;
+
+  beforeEach(async () => {
+    // Import the mocked modules
+    const {
+      getUserProfile,
+      getUserPreferredLanguage,
+      updateUserProfile,
+      updateUserPreferredLanguage,
+      checkUsernameExists,
+      deleteUserAccount,
+    } = await import("../../services/userService");
+
+    mockGetUserProfile = getUserProfile;
+    mockGetUserPreferredLanguage = getUserPreferredLanguage;
+    mockUpdateUserProfile = updateUserProfile;
+    mockUpdateUserPreferredLanguage = updateUserPreferredLanguage;
+    mockCheckUsernameExists = checkUsernameExists;
+    mockDeleteUserAccount = deleteUserAccount;
+
+    // Reset all mocks
+    vi.clearAllMocks();
+    mockChangeLanguage.mockClear();
+
+    // Set up default mock return values
+    mockGetUserProfile.mockResolvedValue({
+      id: "test-user-id",
+      first_name: "John",
+      username: "johndoe",
+      email: "john@example.com",
+    });
+    mockGetUserPreferredLanguage.mockResolvedValue("en");
+    mockUpdateUserProfile.mockResolvedValue(true);
+    mockUpdateUserPreferredLanguage.mockResolvedValue(true);
+    mockCheckUsernameExists.mockResolvedValue(false);
+
+    // Mock localStorage and sessionStorage
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        clear: vi.fn(),
+      },
+      writable: true,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+      value: {
+        clear: vi.fn(),
+      },
+      writable: true,
+    });
+
+    // Mock window.location.href
+    delete window.location;
+    window.location = { href: "" };
+  });
+
+  describe("Component Rendering", () => {
+    it("renders loading state initially", async () => {
+      mockGetUserProfile.mockImplementation(
+        () => new Promise(() => {}) // Never resolves to keep loading
+      );
+
+      render(<AccountSettingsWrapper />);
+
+      expect(screen.getByTestId("loading-acorn")).toBeInTheDocument();
+    });
+
+    it("renders error state when profile loading fails", async () => {
+      mockGetUserProfile.mockRejectedValue(new Error("Failed to load profile"));
+
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Error:/)).toBeInTheDocument();
+      });
+    });
+
+    it("renders account settings form when data loads successfully", async () => {
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByText("ACCOUNT_SETTINGS")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("John")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("johndoe")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("john@example.com")).toBeInTheDocument();
+      });
+    });
+
+    it("renders back arrow that navigates to previous page", async () => {
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByText("ACCOUNT_SETTINGS")).toBeInTheDocument();
+      });
+
+      const backArrow = screen.getByRole("banner").querySelector('.back-arrow-responsive');
+      fireEvent.click(backArrow);
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe("First Name Editing", () => {
+    beforeEach(async () => {
+      render(<AccountSettingsWrapper />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("John")).toBeInTheDocument();
+      });
+    });
+
+    it("enables editing when pencil icon is clicked", () => {
+      const firstNameInput = screen.getByDisplayValue("John");
+      expect(firstNameInput).toHaveAttribute("readonly");
+
+      const firstNameContainer = firstNameInput.closest('.floating-label-input');
+      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      expect(firstNameInput).not.toHaveAttribute("readonly");
+      expect(firstNameInput.className).toContain("input--edit");
+    });
+
+    it("shows check and cancel buttons when editing", () => {
+      const firstNameInput = screen.getByDisplayValue("John");
+      const firstNameContainer = firstNameInput.closest('.floating-label-input');
+      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      expect(firstNameContainer.querySelector('.acc-settings-check')).toBeInTheDocument();
+      expect(firstNameContainer.querySelector('.acc-settings-cancel')).toBeInTheDocument();
+    });
+
+    it("updates first name successfully", async () => {
+      const firstNameInput = screen.getByDisplayValue("John");
+      const firstNameContainer = firstNameInput.closest('.floating-label-input');
+      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      fireEvent.change(firstNameInput, { target: { value: "Jane" } });
+
+      const checkButton = firstNameContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(mockUpdateUserProfile).toHaveBeenCalledWith({ first_name: "Jane" });
+        expect(screen.getByText("successfully_updated_first_name")).toBeInTheDocument();
+      });
+    });
+
+    it("cancels editing when cancel button is clicked", () => {
+      const firstNameInput = screen.getByDisplayValue("John");
+      const firstNameContainer = firstNameInput.closest('.floating-label-input');
+      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      fireEvent.change(firstNameInput, { target: { value: "Jane" } });
+
+      const cancelButton = firstNameContainer.querySelector('.acc-settings-cancel');
+      fireEvent.click(cancelButton);
+
+      expect(firstNameInput).toHaveValue("John");
+      expect(firstNameInput).toHaveAttribute("readonly");
+    });
+  });
+
+  describe("Username Editing", () => {
+    beforeEach(async () => {
+      render(<AccountSettingsWrapper />);
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("johndoe")).toBeInTheDocument();
+      });
+    });
+
+    it("enables username editing", () => {
+      const usernameInput = screen.getByDisplayValue("johndoe");
+      expect(usernameInput).toHaveAttribute("readonly");
+
+      const usernameContainer = usernameInput.closest('.floating-label-input');
+      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      expect(usernameInput).not.toHaveAttribute("readonly");
+    });
+
+    it("updates username successfully", async () => {
+      const usernameInput = screen.getByDisplayValue("johndoe");
+      const usernameContainer = usernameInput.closest('.floating-label-input');
+      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      fireEvent.change(usernameInput, { target: { value: "newusername" } });
+
+      const checkButton = usernameContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(mockCheckUsernameExists).toHaveBeenCalledWith("newusername");
+        expect(mockUpdateUserProfile).toHaveBeenCalledWith({ username: "newusername" });
+        expect(screen.getByText("successfully_updated_username")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error when username already exists", async () => {
+      mockCheckUsernameExists.mockResolvedValue(true);
+
+      const usernameInput = screen.getByDisplayValue("johndoe");
+      const usernameContainer = usernameInput.closest('.floating-label-input');
+      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      fireEvent.change(usernameInput, { target: { value: "existinguser" } });
+
+      const checkButton = usernameContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("username_already_exists")).toBeInTheDocument();
+      });
+
+      expect(mockUpdateUserProfile).not.toHaveBeenCalled();
+    });
+
+    it("clears username error when user types", async () => {
+      mockCheckUsernameExists.mockResolvedValue(true);
+
+      const usernameInput = screen.getByDisplayValue("johndoe");
+      const usernameContainer = usernameInput.closest('.floating-label-input');
+      const pencilIcon = usernameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      fireEvent.change(usernameInput, { target: { value: "existinguser" } });
+
+      const checkButton = usernameContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("username_already_exists")).toBeInTheDocument();
+      });
+
+      // Clear error by typing
+      fireEvent.change(usernameInput, { target: { value: "newuser" } });
+
+      expect(screen.queryByText("username_already_exists")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Password Field", () => {
+    it("renders readonly password field with pencil icon", async () => {
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        const passwordInput = screen.getByDisplayValue("**************");
+        expect(passwordInput).toBeInTheDocument();
+        expect(passwordInput).toHaveAttribute("readonly");
+      });
+    });
+
+    it("navigates to change password page when pencil is clicked", async () => {
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("**************")).toBeInTheDocument();
+      });
+
+      const passwordInput = screen.getByDisplayValue("**************");
+      const passwordContainer = passwordInput.closest('.floating-label-input');
+      const pencilIcon = passwordContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/change-password", { 
+        state: { fromAccountSettings: true } 
+      });
+    });
+  });
+
+  describe("Language Preferences", () => {
+    beforeEach(async () => {
+      render(<AccountSettingsWrapper />);
+      await waitFor(() => {
+        expect(screen.getByText("PREFERRED_LANGUAGE")).toBeInTheDocument();
+      });
+    });
+
+    it("displays current language selection", () => {
+      expect(screen.getByText("EN")).toBeInTheDocument();
+      expect(screen.getByText("DE")).toBeInTheDocument();
+      
+      // EN should be selected by default (mocked to return "en")
+      const enSpan = screen.getByText("EN");
+      expect(enSpan.className).toContain("selected");
+    });
+
+    it("enables language editing when pencil is clicked", () => {
+      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
+      const pencilIcon = languageContainer.querySelector('.btn');
+      fireEvent.click(pencilIcon);
+
+      // Language options should become clickable
+      const enOption = screen.getByText("EN");
+      const deOption = screen.getByText("DE");
+      expect(enOption).toBeInTheDocument();
+      expect(deOption).toBeInTheDocument();
+    });
+
+    it("updates language preference successfully", async () => {
+      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
+      const pencilIcon = languageContainer.querySelector('.btn');
+      fireEvent.click(pencilIcon);
+
+      // Click on DE option
+      const deOption = screen.getByText("DE");
+      fireEvent.click(deOption);
+
+      // Click check button
+      const checkButton = languageContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(mockUpdateUserPreferredLanguage).toHaveBeenCalledWith("de");
+        expect(mockChangeLanguage).toHaveBeenCalledWith("de");
+        expect(screen.getByText("successfully_updated_language")).toBeInTheDocument();
+      });
+    });
+
+    it("cancels language editing", () => {
+      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
+      const pencilIcon = languageContainer.querySelector('.btn');
+      fireEvent.click(pencilIcon);
+
+      // Click on DE option
+      const deOption = screen.getByText("DE");
+      fireEvent.click(deOption);
+
+      // Click cancel button
+      const cancelButton = languageContainer.querySelector('.acc-settings-cancel');
+      fireEvent.click(cancelButton);
+
+      // Should return to non-editing state - pencil icon should be back
+      expect(languageContainer.querySelector('.acc-settings-cancel')).not.toBeInTheDocument();
+      expect(languageContainer.querySelector('.btn')).toBeInTheDocument();
+    });
+  });
+
+  describe("Delete Account", () => {
+    beforeEach(async () => {
+      render(<AccountSettingsWrapper />);
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "delete_account" })).toBeInTheDocument();
+      });
+    });
+
+    it("renders delete account button", () => {
+      expect(screen.getByRole("button", { name: "delete_account" })).toBeInTheDocument();
+    });
+
+    it("opens confirmation modal when delete button is clicked", () => {
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+
+      expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+      expect(screen.getByText("delete_account")).toBeInTheDocument();
+      expect(screen.getByText("delete_account_confirmation")).toBeInTheDocument();
+    });
+
+    it("displays confirmation checkbox with warning text", () => {
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+
+      expect(screen.getByTestId("confirmation-checkbox")).toBeInTheDocument();
+      expect(screen.getByText("delete_account_warning")).toBeInTheDocument();
+    });
+
+    it("disables confirm button initially when checkbox is required", () => {
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+
+      const confirmButton = screen.getByTestId("modal-confirm");
+      expect(confirmButton).toBeDisabled();
+    });
+
+    it("enables confirm button when checkbox is checked", async () => {
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+
+      const checkbox = screen.getByTestId("confirmation-checkbox");
+      const confirmButton = screen.getByTestId("modal-confirm");
+
+      expect(confirmButton).toBeDisabled();
+
+      fireEvent.click(checkbox);
+
+      await waitFor(() => {
+        expect(confirmButton).not.toBeDisabled();
+      });
+    });
+
+    it("closes modal when cancel button is clicked", () => {
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+      fireEvent.click(screen.getByTestId("modal-cancel"));
+
+      expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
+    });
+
+    it("calls deleteUserAccount when confirmed", async () => {
+      mockDeleteUserAccount.mockResolvedValue();
+
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+      fireEvent.click(screen.getByTestId("confirmation-checkbox"));
+      fireEvent.click(screen.getByTestId("modal-confirm"));
+
+      await waitFor(() => {
+        expect(mockDeleteUserAccount).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("shows success message with user's name after successful deletion", async () => {
+      mockDeleteUserAccount.mockResolvedValue();
+
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+      fireEvent.click(screen.getByTestId("confirmation-checkbox"));
+      fireEvent.click(screen.getByTestId("modal-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByText("account_deleted_goodbye_John")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
+    });
+
+    it("clears localStorage and sessionStorage after successful deletion", async () => {
+      mockDeleteUserAccount.mockResolvedValue();
+
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+      fireEvent.click(screen.getByTestId("confirmation-checkbox"));
+      fireEvent.click(screen.getByTestId("modal-confirm"));
+
+      await waitFor(() => {
+        expect(window.localStorage.clear).toHaveBeenCalled();
+        expect(window.sessionStorage.clear).toHaveBeenCalled();
+      });
+    });
+
+    it("shows error message when deletion fails", async () => {
+      const errorMessage = "Failed to delete account";
+      mockDeleteUserAccount.mockRejectedValue(new Error(errorMessage));
+
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+      fireEvent.click(screen.getByTestId("confirmation-checkbox"));
+      fireEvent.click(screen.getByTestId("modal-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/delete_account_error/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId("confirmation-modal")).not.toBeInTheDocument();
+      expect(screen.queryByText("account_deleted_goodbye_John")).not.toBeInTheDocument();
+    });
+
+    it("handles deletion error and keeps user on page", async () => {
+      mockDeleteUserAccount.mockRejectedValue(new Error("Network error"));
+
+      fireEvent.click(screen.getByRole("button", { name: "delete_account" }));
+      fireEvent.click(screen.getByTestId("confirmation-checkbox"));
+      fireEvent.click(screen.getByTestId("modal-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/delete_account_error/)).toBeInTheDocument();
+      });
+
+      // After error, the full form is no longer displayed - just the error message
+      expect(screen.queryByRole("button", { name: "delete_account" })).not.toBeInTheDocument();
+      expect(window.localStorage.clear).not.toHaveBeenCalled();
+      expect(window.sessionStorage.clear).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Success Messages", () => {
+    it("displays success messages temporarily", async () => {
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("John")).toBeInTheDocument();
+      });
+
+      // Trigger a successful update
+      const firstNameInput = screen.getByDisplayValue("John");
+      const firstNameContainer = firstNameInput.closest('.floating-label-input');
+      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      fireEvent.change(firstNameInput, { target: { value: "Jane" } });
+
+      const checkButton = firstNameContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("successfully_updated_first_name")).toBeInTheDocument();
+      });
+
+      // Success message should be visible in the header
+      const header = screen.getByRole("banner") || screen.getByText("successfully_updated_first_name").closest("header");
+      expect(header).toContainElement(screen.getByText("successfully_updated_first_name"));
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("handles service errors gracefully", async () => {
+      mockUpdateUserProfile.mockRejectedValue(new Error("Service unavailable"));
+
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("John")).toBeInTheDocument();
+      });
+
+      const firstNameInput = screen.getByDisplayValue("John");
+      const firstNameContainer = firstNameInput.closest('.floating-label-input');
+      const pencilIcon = firstNameContainer.querySelector('.btn-icon-right');
+      fireEvent.click(pencilIcon);
+
+      fireEvent.change(firstNameInput, { target: { value: "Jane" } });
+
+      const checkButton = firstNameContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Error:/)).toBeInTheDocument();
+      });
+    });
+
+    it("handles language update errors", async () => {
+      mockUpdateUserPreferredLanguage.mockRejectedValue(new Error("Language service error"));
+
+      render(<AccountSettingsWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByText("PREFERRED_LANGUAGE")).toBeInTheDocument();
+      });
+
+      const languageContainer = screen.getByText("EN").closest('.acc-settings-language-container');
+      const pencilIcon = languageContainer.querySelector('.btn');
+      fireEvent.click(pencilIcon);
+
+      const deOption = screen.getByText("DE");
+      fireEvent.click(deOption);
+
+      const checkButton = languageContainer.querySelector('.acc-settings-check');
+      fireEvent.click(checkButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Error:/)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/pages/AuthPage/AuthPage.jsx
+++ b/src/pages/AuthPage/AuthPage.jsx
@@ -49,15 +49,15 @@ const AuthPage = ({ setLoginMessage }) => {
     if (error) {
       // Handle specific error types
       switch (error.type) {
-        case 'USER_NOT_FOUND':
+        case "USER_NOT_FOUND":
           setValidationErrors({ username: t(error.translationKey) });
           break;
-        case 'INVALID_PASSWORD':
+        case "INVALID_PASSWORD":
           setValidationErrors({ password: t(error.translationKey) });
           break;
-        case 'EMAIL_NOT_CONFIRMED':
-        case 'TOO_MANY_REQUESTS':
-        case 'GENERAL_ERROR':
+        case "EMAIL_NOT_CONFIRMED":
+        case "TOO_MANY_REQUESTS":
+        case "GENERAL_ERROR":
         default:
           setErrorMessage(t(error.translationKey));
           break;
@@ -167,10 +167,7 @@ const AuthPage = ({ setLoginMessage }) => {
       <div className="auth-container">
         {/* Headers to toggle between modes */}
         <header className="flex-row">
-          <ArrowBigLeft
-            className="back-arrow-left"
-            onClick={() => navigate(-1)}
-          />
+          <ArrowBigLeft className="back-arrow" onClick={() => navigate(-1)} />
           <button
             className={`subheading-wrapper ${!isSignUpMode ? "selected" : ""}`}
             type="button"
@@ -271,7 +268,9 @@ const AuthPage = ({ setLoginMessage }) => {
                   validationErrors.username ? "input--error" : ""
                 }`}
               />
-              <label htmlFor="username">{t("username_or_email")}</label>
+              <label htmlFor="username">
+                {isSignUpMode ? t("username") : t("username_or_email")}
+              </label>
             </div>
             {validationErrors.username && (
               <span className="error-message-small">

--- a/src/pages/AuthPage/AuthPage.jsx
+++ b/src/pages/AuthPage/AuthPage.jsx
@@ -65,6 +65,10 @@ const AuthPage = ({ setLoginMessage }) => {
     } else {
       setLoginMessage(t("login_success"));
 
+      // Clear form fields on successful login
+      setUsername("");
+      setPassword("");
+
       // Navigate on successful login
       navigate("/");
     }
@@ -75,9 +79,6 @@ const AuthPage = ({ setLoginMessage }) => {
       setErrorMessage("");
       setValidationErrors({});
     }, 3000);
-
-    setUsername("");
-    setPassword("");
   };
 
   const handleSignUp = async (e) => {

--- a/src/pages/AuthPage/AuthPage.test.jsx
+++ b/src/pages/AuthPage/AuthPage.test.jsx
@@ -75,8 +75,12 @@ describe("AuthPage", () => {
   beforeEach(async () => {
     // Import the mocked functions
     const { signUp, signIn } = await import("../../services/auth");
-    const { validateAuthForm, validateUsernameUnique, validateEmailUnique, isPasswordStrong } =
-      await import("../../utils/validation");
+    const {
+      validateAuthForm,
+      validateUsernameUnique,
+      validateEmailUnique,
+      isPasswordStrong,
+    } = await import("../../utils/validation");
 
     mockSignUp = signUp;
     mockSignIn = signIn;
@@ -219,7 +223,7 @@ describe("AuthPage", () => {
       fireEvent.click(signUpHeaderButton);
 
       // Fields should be cleared
-      expect(screen.getByLabelText("username_or_email").value).toBe("");
+      expect(screen.getByLabelText("username").value).toBe("");
       expect(screen.getByTestId("password-input").value).toBe("");
     });
 
@@ -238,7 +242,9 @@ describe("AuthPage", () => {
 
       // Should show password requirements
       expect(screen.getByTestId("password-requirements")).toBeInTheDocument();
-      expect(screen.getByText("Password requirements for: testpass")).toBeInTheDocument();
+      expect(
+        screen.getByText("Password requirements for: testpass")
+      ).toBeInTheDocument();
     });
 
     it("does not show password requirements in login mode", () => {
@@ -249,7 +255,9 @@ describe("AuthPage", () => {
       fireEvent.change(passwordInput, { target: { value: "testpass" } });
 
       // Should not show password requirements
-      expect(screen.queryByTestId("password-requirements")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("password-requirements")
+      ).not.toBeInTheDocument();
     });
 
     it("does not show password requirements when password is empty", () => {
@@ -262,7 +270,9 @@ describe("AuthPage", () => {
       fireEvent.click(signUpHeaderButton);
 
       // Password is empty by default
-      expect(screen.queryByTestId("password-requirements")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("password-requirements")
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -291,7 +301,7 @@ describe("AuthPage", () => {
 
       const emailInput = screen.getByLabelText("email");
       const firstNameInput = screen.getByLabelText("first_name");
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -401,7 +411,7 @@ describe("AuthPage", () => {
       });
       fireEvent.click(signUpHeaderButton);
 
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       fireEvent.change(usernameInput, { target: { value: "existinguser" } });
 
       const form = screen.getByTestId("auth-form");
@@ -462,7 +472,7 @@ describe("AuthPage", () => {
       fireEvent.click(signUpHeaderButton);
 
       const emailInput = screen.getByLabelText("email");
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       fireEvent.change(emailInput, {
         target: { value: "existing@example.com" },
       });
@@ -503,7 +513,7 @@ describe("AuthPage", () => {
 
       const emailInput = screen.getByLabelText("email");
       const firstNameInput = screen.getByLabelText("first_name");
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "unique@example.com" } });
@@ -547,7 +557,7 @@ describe("AuthPage", () => {
 
       const emailInput = screen.getByLabelText("email");
       const firstNameInput = screen.getByLabelText("first_name");
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -560,7 +570,9 @@ describe("AuthPage", () => {
 
       await waitFor(() => {
         expect(mockIsPasswordStrong).toHaveBeenCalledWith("weak");
-        expect(screen.getByText("password_requirements_not_met")).toBeInTheDocument();
+        expect(
+          screen.getByText("password_requirements_not_met")
+        ).toBeInTheDocument();
         expect(mockValidateUsernameUnique).toHaveBeenCalled();
         expect(mockValidateEmailUnique).toHaveBeenCalled();
         expect(mockSignUp).not.toHaveBeenCalled();
@@ -583,10 +595,12 @@ describe("AuthPage", () => {
 
       const emailInput = screen.getByLabelText("email");
       const firstNameInput = screen.getByLabelText("first_name");
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
-      fireEvent.change(emailInput, { target: { value: "existing@example.com" } });
+      fireEvent.change(emailInput, {
+        target: { value: "existing@example.com" },
+      });
       fireEvent.change(firstNameInput, { target: { value: "John" } });
       fireEvent.change(usernameInput, { target: { value: "existinguser" } });
       fireEvent.change(passwordInput, { target: { value: "weak" } });
@@ -596,7 +610,9 @@ describe("AuthPage", () => {
 
       await waitFor(() => {
         // All three validation errors should be displayed simultaneously
-        expect(screen.getByText("password_requirements_not_met")).toBeInTheDocument();
+        expect(
+          screen.getByText("password_requirements_not_met")
+        ).toBeInTheDocument();
         expect(screen.getByText("username_already_exists")).toBeInTheDocument();
         expect(screen.getByText("email_already_exists")).toBeInTheDocument();
         expect(mockSignUp).not.toHaveBeenCalled();
@@ -664,8 +680,8 @@ describe("AuthPage", () => {
 
     it("handles login error - user not found", async () => {
       mockValidateAuthForm.mockReturnValue({});
-      mockSignIn.mockResolvedValue({ 
-        error: { type: 'USER_NOT_FOUND', translationKey: 'user_not_found' } 
+      mockSignIn.mockResolvedValue({
+        error: { type: "USER_NOT_FOUND", translationKey: "user_not_found" },
       });
 
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
@@ -680,8 +696,8 @@ describe("AuthPage", () => {
 
     it("handles login error - invalid password", async () => {
       mockValidateAuthForm.mockReturnValue({});
-      mockSignIn.mockResolvedValue({ 
-        error: { type: 'INVALID_PASSWORD', translationKey: 'invalid_password' } 
+      mockSignIn.mockResolvedValue({
+        error: { type: "INVALID_PASSWORD", translationKey: "invalid_password" },
       });
 
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
@@ -696,8 +712,8 @@ describe("AuthPage", () => {
 
     it("handles login error - general error", async () => {
       mockValidateAuthForm.mockReturnValue({});
-      mockSignIn.mockResolvedValue({ 
-        error: { type: 'GENERAL_ERROR', translationKey: 'login_failed' } 
+      mockSignIn.mockResolvedValue({
+        error: { type: "GENERAL_ERROR", translationKey: "login_failed" },
       });
 
       render(<AuthPageWrapper setLoginMessage={mockSetLoginMessage} />);
@@ -760,7 +776,9 @@ describe("AuthPage", () => {
       const usernameInput = screen.getByLabelText("username_or_email");
       const passwordInput = screen.getByTestId("password-input");
 
-      fireEvent.change(usernameInput, { target: { value: "test@example.com" } });
+      fireEvent.change(usernameInput, {
+        target: { value: "test@example.com" },
+      });
       fireEvent.change(passwordInput, { target: { value: "testpass" } });
 
       const form = screen.getByTestId("auth-form");
@@ -787,7 +805,7 @@ describe("AuthPage", () => {
 
       const emailInput = screen.getByLabelText("email");
       const firstNameInput = screen.getByLabelText("first_name");
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });
@@ -863,7 +881,7 @@ describe("AuthPage", () => {
 
       const emailInput = screen.getByLabelText("email");
       const firstNameInput = screen.getByLabelText("first_name");
-      const usernameInput = screen.getByLabelText("username_or_email");
+      const usernameInput = screen.getByLabelText("username");
       const passwordInput = screen.getByTestId("password-input");
 
       fireEvent.change(emailInput, { target: { value: "test@example.com" } });

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -164,3 +164,33 @@ export const updateUserProfile = async (updates) => {
     throw error;
   }
 };
+
+// Delete user account
+export const deleteUserAccount = async () => {
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new Error("User not authenticated");
+
+    // Delete user data from users table (this should trigger auth user deletion via database trigger)
+    const { error: profileError } = await supabase
+      .from("users")
+      .delete()
+      .eq("id", user.id);
+
+    if (profileError) throw profileError;
+
+    // Sign out the user to clear the session
+    const { error: signOutError } = await supabase.auth.signOut();
+    if (signOutError) {
+      console.error("Error signing out:", signOutError);
+      // Don't throw here, account is already deleted
+    }
+
+    return true;
+  } catch (error) {
+    console.error("Error deleting user account:", error);
+    throw error;
+  }
+};

--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -76,6 +76,15 @@
   box-shadow: 0 0.25rem 0.5rem var(--shadow-black);
 }
 
+.btn-danger:disabled:hover {
+  opacity: 0.5;
+  background: white;
+  color: var(--error-red);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
 /* Icon buttons */
 .btn-icon {
   padding: 0.5rem;

--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -53,7 +53,7 @@
 
 .btn-secondary {
   color: var(--brown);
-  border: var(--border-width-thick) dotted var(--brown);
+  border: var(--border-width-thick) dashed var(--brown);
   padding: 0.5rem;
   background: white;
 }
@@ -66,12 +66,12 @@
 
 .btn-danger {
   background: white;
-  color: var(--red);
-  border: var(--border-width-thick) solid var(--red);
+  color: var(--error-red);
+  border: var(--border-width-thick) dashed var(--error-red);
 }
 
 .btn-danger:hover {
-  background: var(--red);
+  background: var(--error-red);
   color: white;
   box-shadow: 0 0.25rem 0.5rem var(--shadow-black);
 }
@@ -114,7 +114,7 @@
   flex-shrink: 0;
 }
 
-.btn-icon-password {
+.btn-icon-right {
   color: var(--brown);
   padding: 0.25rem;
   position: absolute;
@@ -127,7 +127,7 @@
   transform: translateY(-1px);
 }
 
-.btn-icon-password:hover {
+.btn-icon-right:hover {
   color: var(--dark-red);
 }
 
@@ -147,6 +147,10 @@
   position: absolute;
   padding-left: 3rem;
   cursor: pointer;
+}
+
+.auth-container .back-arrow {
+  color: var(--brown);
 }
 
 /* Add section buttons */

--- a/src/styles/components/inputs.css
+++ b/src/styles/components/inputs.css
@@ -54,7 +54,6 @@
 }
 
 .input--password {
-  width: 100%;
   padding-right: 2.5rem; /* Make room for the eye icon */
 }
 
@@ -89,7 +88,6 @@
   position: relative;
   display: flex;
   align-items: center;
-  width: 100%;
 }
 
 .input-with-icon input,
@@ -101,7 +99,7 @@
   position: absolute;
   left: 0.75rem;
   color: var(--dark-brown);
-  z-index: 1;
+  z-index: var(--z-content);
 }
 
 /* All inputs inside input-with-icon container should have left padding for icon space */
@@ -116,21 +114,22 @@
 }
 
 /* Fix eye icon positioning - override the general svg rule */
-.input-with-icon .btn-icon-password svg {
+.input-with-icon .btn-icon-right svg {
   position: static;
   left: auto;
-  z-index: auto;
+  z-index: var(--z-content);
 }
 
 /* Floating Label Inside Input */
 .floating-label-input {
   position: relative;
-  width: 100%;
+  min-width: 18rem;
 }
 
 .floating-label-input input {
   padding: 1.2rem 0.75rem 0.5rem 0.75rem;
   transition: all 0.2s ease;
+  min-width: 18rem;
 }
 
 .floating-label-input label {

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -31,8 +31,7 @@
 
 .confirmation-modal-message {
   color: var(--dark-brown);
-  margin: 0 0 1.5rem 0;
-  line-height: 1.5;
+  margin: 0 0 1rem 0;
   font-weight: 500;
 }
 
@@ -62,7 +61,6 @@
 /* Responsive Design */
 @media (max-width: 768px) {
   .confirmation-modal-content {
-    padding: 1rem;
     min-width: 16rem;
     margin: 0.5rem;
   }

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -42,10 +42,28 @@
   gap: 1rem;
 }
 
+/* Confirmation checkbox */
+.confirmation-checkbox-wrapper {
+  margin-bottom: 1rem;
+}
+
+.confirmation-checkbox-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-size: 0.9rem;
+  gap: 0.5rem;
+}
+
+.confirmation-checkbox-text {
+  user-select: none;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .confirmation-modal-content {
     padding: 1rem;
     min-width: 16rem;
+    margin: 0.5rem;
   }
 }

--- a/src/styles/layout/containers.css
+++ b/src/styles/layout/containers.css
@@ -126,11 +126,9 @@
 
 /* Input wrappers */
 .input-validation-wrapper {
-  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-width: 18rem;
 }
 
 /* Subheading wrappers */


### PR DESCRIPTION
- Add delete account button to AccountSettings page with popup confirmation modal
- Add real-time filtering when searching for recipes
- Add unit tests for AccountSettings

**Minor fixes:**
- Allow duplicate ingredients in a recipe and improve temp id function to ensure uniqueness
- Adding ingredients in non-English languages now works translates and pluralises correctly 
- Don't clear login fields when there is a validation error for sign in/sign up 
- Close account settings when clicking away i.e. updating username 

<img width="200" alt="localhost_5173_account-settings(iPhone 12 Pro) (10)" src="https://github.com/user-attachments/assets/0f1aaceb-ac90-44a8-8309-6062bc5099d1" />
<img width="200" alt="localhost_5173_account-settings(iPhone 12 Pro) (13)" src="https://github.com/user-attachments/assets/c05011ca-a81a-4711-915b-1c699b1e0399" />
<img width="200" alt="localhost_5173_account-settings(iPhone 12 Pro) (14)" src="https://github.com/user-attachments/assets/874092b9-da1b-429e-a7a5-453edefad109" />
<img width="200" alt="localhost_5173_account-settings(iPhone 12 Pro) (12)" src="https://github.com/user-attachments/assets/c7d8f4c2-da6f-45e9-a568-a2f81d63347f" />

