### PR TITLE
Implement Ingredient-Recipe linking. 

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -186,9 +186,11 @@
   "section_title": "Bereichstitel",
   "add_instruction": "Anweisung hinzufügen",
   "remove_instruction": "Anweisung entfernen",
-  
+
   "link_to_recipe": "Mit Rezept verknüpfen",
+  "unlink_recipe": "Verknüpfung entfernen",
   "search_recipes": "Rezepte suchen...",
+  "failed_load_shared_recipe": "Geteiltes Rezept konnte nicht geladen werden",
 
   "add_new_recipe": "Neues Rezept Hinzufügen",
   "edit_recipe": "Rezept bearbeiten",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -186,6 +186,9 @@
   "section_title": "Bereichstitel",
   "add_instruction": "Anweisung hinzufügen",
   "remove_instruction": "Anweisung entfernen",
+  
+  "link_to_recipe": "Mit Rezept verknüpfen",
+  "search_recipes": "Rezepte suchen...",
 
   "add_new_recipe": "Neues Rezept Hinzufügen",
   "edit_recipe": "Rezept bearbeiten",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -186,6 +186,9 @@
   "section_title": "Section title",
   "add_instruction": "Add instruction",
   "remove_instruction": "Remove instruction",
+  
+  "link_to_recipe": "Link to Recipe",
+  "search_recipes": "Search recipes...",
 
   "add_new_recipe": "Add New Recipe",
   "edit_recipe": "Edit Recipe",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -186,9 +186,11 @@
   "section_title": "Section title",
   "add_instruction": "Add instruction",
   "remove_instruction": "Remove instruction",
-  
+
   "link_to_recipe": "Link to Recipe",
+  "unlink_recipe": "Remove link",
   "search_recipes": "Search recipes...",
+  "failed_load_shared_recipe": "Failed to load shared recipe",
 
   "add_new_recipe": "Add New Recipe",
   "edit_recipe": "Edit Recipe",

--- a/src/components/ImageUpload/ImageUpload.jsx
+++ b/src/components/ImageUpload/ImageUpload.jsx
@@ -172,9 +172,7 @@ const ImageUpload = ({
         onDrop={handleDrop}
       >
         <Upload className="upload-icon" size={32} />
-        <div className="upload-text">
-          <strong>{t("upload_images")}</strong>
-        </div>
+        <div className="bold-small">{t("upload_images")}</div>
         <div className="upload-hint">{t("click_or_drag")}</div>
         <div className="upload-hint">{t("image_upload_hint")}</div>
       </div>

--- a/src/components/RecipeForm/RecipeForm.css
+++ b/src/components/RecipeForm/RecipeForm.css
@@ -133,7 +133,7 @@
   color: var(--color-danger);
 }
 
-/* Link button styling */
+/* Base link button styling */
 .btn-icon-link {
   color: var(--color-text-primary);
   transition: all 0.2s ease;
@@ -146,31 +146,27 @@
   color: var(--color-danger);
 }
 
-/* Linked button styling */
-.btn-icon-linked {
+/* Linked state modifier */
+.btn-icon-link.linked {
   color: var(--color-danger);
-  transition: all 0.2s ease;
-  border: 2px dashed var(--color-danger) !important;
-  border-radius: var(--border-radius);
-  padding: 0.3rem !important;
+  border-color: var(--color-danger) !important;
 }
 
-/* Hover X icon functionality for link buttons */
-.btn-icon-linked .link-hover {
-  display: none;
-}
-
-.btn-icon-linked:hover .link-default {
-  display: none;
-}
-
-.btn-icon-linked:hover .link-hover {
-  display: block;
-}
-
-/* For unlinked buttons, only show the default link icon */
+/* Icon visibility rules */
 .btn-icon-link .link-hover {
   display: none;
+}
+
+.btn-icon-link.linked .link-hover {
+  display: none;
+}
+
+.btn-icon-link.linked:hover .link-default {
+  display: none;
+}
+
+.btn-icon-link.linked:hover .link-hover {
+  display: block;
 }
 
 /* Responsive */

--- a/src/components/RecipeForm/RecipeForm.css
+++ b/src/components/RecipeForm/RecipeForm.css
@@ -130,10 +130,8 @@
 }
 
 .source-toggle:hover {
-  color: var(--color-danger-dark);
+  color: var(--color-danger);
 }
-
-/* TODO - FROM HERE */
 
 /* Link button styling */
 .btn-icon-link {
@@ -142,29 +140,43 @@
 }
 
 .btn-icon-link:hover {
-  color: var(--color-danger-dark);
+  color: var(--color-danger);
 }
 
 /* Linked button styling */
 .btn-icon-linked {
-  color: var(--color-danger-dark);
+  color: var(--color-danger);
   transition: all 0.2s ease;
 }
 
 .btn-icon-linked:hover {
   /* TODO - make it clear this will remove the current link i.e change into an x */
-  color: var(--color-danger-dark);
+  color: var(--color-danger);
 }
 
-/* Ingredient name styling for linked ingredients */
-.ingredient-linked {
-  text-decoration: underline;
-  text-decoration-color: var(--color-danger-dark);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
+/* Ingredient name styling for linked ingredients - color + italic styling */
+.input.ingredient-linked {
+  color: var(--color-danger) !important;
+  font-weight: 500 !important;
 }
 
-/* TODO - TO HERE */
+/* Hover X icon functionality for link buttons */
+.btn-icon-linked .link-hover {
+  display: none;
+}
+
+.btn-icon-linked:hover .link-default {
+  display: none;
+}
+
+.btn-icon-linked:hover .link-hover {
+  display: block;
+}
+
+/* For unlinked buttons, only show the default link icon */
+.btn-icon-link .link-hover {
+  display: none;
+}
 
 /* Responsive */
 @media (max-width: 768px) {

--- a/src/components/RecipeForm/RecipeForm.css
+++ b/src/components/RecipeForm/RecipeForm.css
@@ -160,7 +160,7 @@
 .ingredient-linked {
   text-decoration: underline;
   text-decoration-color: var(--color-danger-dark);
-  text-decoration-thickness: 2px;
+  text-decoration-thickness: 1px;
   text-underline-offset: 2px;
 }
 

--- a/src/components/RecipeForm/RecipeForm.css
+++ b/src/components/RecipeForm/RecipeForm.css
@@ -68,7 +68,7 @@
 /* Ingredient rows */
 .ingredient-row {
   display: grid;
-  grid-template-columns: auto 2fr 1fr 1fr 2fr auto;
+  grid-template-columns: auto 2fr 1fr 1fr 2fr auto auto;
   gap: 0.5rem;
   align-items: center;
   border-radius: var(--border-radius);
@@ -133,6 +133,39 @@
   color: var(--color-danger-dark);
 }
 
+/* TODO - FROM HERE */
+
+/* Link button styling */
+.btn-icon-link {
+  color: var(--color-text-primary);
+  transition: all 0.2s ease;
+}
+
+.btn-icon-link:hover {
+  color: var(--color-danger-dark);
+}
+
+/* Linked button styling */
+.btn-icon-linked {
+  color: var(--color-danger-dark);
+  transition: all 0.2s ease;
+}
+
+.btn-icon-linked:hover {
+  /* TODO - make it clear this will remove the current link i.e change into an x */
+  color: var(--color-danger-dark);
+}
+
+/* Ingredient name styling for linked ingredients */
+.ingredient-linked {
+  text-decoration: underline;
+  text-decoration-color: var(--color-danger-dark);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
+
+/* TODO - TO HERE */
+
 /* Responsive */
 @media (max-width: 768px) {
   /* Title and servings stack on mobile */
@@ -163,6 +196,6 @@
     gap: 0.25rem;
     align-items: center;
     display: grid;
-    grid-template-columns: 1.5fr 2fr 2fr auto;
+    grid-template-columns: 1.5fr 2fr 2fr auto auto;
   }
 }

--- a/src/components/RecipeForm/RecipeForm.css
+++ b/src/components/RecipeForm/RecipeForm.css
@@ -198,16 +198,45 @@
   }
 
   .ingredient-content {
-    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
   }
 
+  /* Make ingredient name and buttons share the same row on mobile */
+  .ingredient-content > input:first-child,
+  .ingredient-content .flex-row {
+    order: -1;
+  }
+
+  .ingredient-content > input:first-child {
+    flex: 1;
+  }
+
+  .ingredient-content .flex-row {
+    flex-shrink: 0;
+  }
+
+  /* Change ingredient-content to row layout for the first row */
+  .ingredient-content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+  }
+
+  /* Force ingredient-details to next line */
   .ingredient-details {
+    flex-basis: 100%;
+    order: 1;
+  }
+
+  .ingredient-details {
+    display: flex;
     gap: 0.25rem;
     align-items: center;
     display: grid;
-    grid-template-columns: 1.5fr 2fr 2fr auto auto;
+    grid-template-columns: 1.5fr 2fr 2fr;
   }
 }

--- a/src/components/RecipeForm/RecipeForm.css
+++ b/src/components/RecipeForm/RecipeForm.css
@@ -137,6 +137,9 @@
 .btn-icon-link {
   color: var(--color-text-primary);
   transition: all 0.2s ease;
+  border: 2px dashed transparent !important;
+  border-radius: var(--border-radius);
+  padding: 0.3rem !important;
 }
 
 .btn-icon-link:hover {
@@ -147,17 +150,9 @@
 .btn-icon-linked {
   color: var(--color-danger);
   transition: all 0.2s ease;
-}
-
-.btn-icon-linked:hover {
-  /* TODO - make it clear this will remove the current link i.e change into an x */
-  color: var(--color-danger);
-}
-
-/* Ingredient name styling for linked ingredients - color + italic styling */
-.input.ingredient-linked {
-  color: var(--color-danger) !important;
-  font-weight: 500 !important;
+  border: 2px dashed var(--color-danger) !important;
+  border-radius: var(--border-radius);
+  padding: 0.3rem !important;
 }
 
 /* Hover X icon functionality for link buttons */

--- a/src/components/RecipeForm/RecipeForm.jsx
+++ b/src/components/RecipeForm/RecipeForm.jsx
@@ -402,13 +402,6 @@ const RecipeForm = ({
                                   validationErrors.ingredients
                                     ? "input--error"
                                     : ""
-                                } ${
-                                  getIngredientLink(
-                                    "ungrouped",
-                                    ingredient.tempId
-                                  )
-                                    ? "ingredient-linked"
-                                    : ""
                                 }`}
                                 placeholder={t("ingredient_name")}
                               />
@@ -797,14 +790,7 @@ const RecipeForm = ({
                                                     validationErrors.ingredients
                                                       ? "input--error"
                                                       : ""
-                                                  } ${
-                                                    getIngredientLink(
-                                                      section.id,
-                                                      ingredient.tempId
-                                                    )
-                                                      ? "ingredient-linked"
-                                                      : ""
-                                                  }`}
+                                                  } `}
                                                   placeholder={t(
                                                     "ingredient_name"
                                                   )}

--- a/src/components/RecipeForm/RecipeForm.jsx
+++ b/src/components/RecipeForm/RecipeForm.jsx
@@ -509,88 +509,89 @@ const RecipeForm = ({
                                   className="input input--full-width input--edit"
                                   placeholder={t("notes")}
                                 />
-                                <div className="flex-row">
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      const linkedRecipe = getIngredientLink(
+                              </div>
+
+                              <div className="flex-row">
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    const linkedRecipe = getIngredientLink(
+                                      "ungrouped",
+                                      ingredient.tempId
+                                    );
+                                    if (linkedRecipe) {
+                                      removeIngredientLink(
                                         "ungrouped",
                                         ingredient.tempId
                                       );
-                                      if (linkedRecipe) {
-                                        removeIngredientLink(
-                                          "ungrouped",
-                                          ingredient.tempId
-                                        );
-                                      } else {
-                                        handleOpenLinkDropdown(
-                                          "ungrouped",
-                                          ingredient.tempId,
-                                          ingredient
-                                        );
-                                      }
-                                    }}
-                                    className={`btn btn-icon ${
-                                      getIngredientLink(
+                                    } else {
+                                      handleOpenLinkDropdown(
                                         "ungrouped",
-                                        ingredient.tempId
-                                      )
-                                        ? "btn-icon-linked"
-                                        : "btn-icon-link"
-                                    } ${
-                                      isEditingTranslation
-                                        ? "translation-disabled"
-                                        : ""
-                                    }`}
-                                    aria-label={
-                                      getIngredientLink(
-                                        "ungrouped",
-                                        ingredient.tempId
-                                      )
-                                        ? "Remove link"
-                                        : "Link to recipe"
+                                        ingredient.tempId,
+                                        ingredient
+                                      );
                                     }
-                                    disabled={isEditingTranslation}
-                                    title={
-                                      getIngredientLink(
-                                        "ungrouped",
-                                        ingredient.tempId
-                                      )
-                                        ? `Linked to ${
-                                            getIngredientLink(
-                                              "ungrouped",
-                                              ingredient.tempId
-                                            ).title
-                                          }`
-                                        : "Link to recipe"
-                                    }
-                                  >
-                                    <Link size={16} className="link-default" />
-                                    <X size={16} className="link-hover" />
-                                  </button>
+                                  }}
+                                  className={`btn btn-icon ${
+                                    getIngredientLink(
+                                      "ungrouped",
+                                      ingredient.tempId
+                                    )
+                                      ? "btn-icon-linked"
+                                      : "btn-icon-link"
+                                  } ${
+                                    isEditingTranslation
+                                      ? "translation-disabled"
+                                      : ""
+                                  }`}
+                                  aria-label={
+                                    getIngredientLink(
+                                      "ungrouped",
+                                      ingredient.tempId
+                                    )
+                                      ? "Remove link"
+                                      : "Link to recipe"
+                                  }
+                                  disabled={isEditingTranslation}
+                                  title={
+                                    getIngredientLink(
+                                      "ungrouped",
+                                      ingredient.tempId
+                                    )
+                                      ? `Linked to ${
+                                          getIngredientLink(
+                                            "ungrouped",
+                                            ingredient.tempId
+                                          ).title
+                                        }`
+                                      : "Link to recipe"
+                                  }
+                                >
+                                  <Link size={16} className="link-default" />
+                                  <X size={16} className="link-hover" />
+                                </button>
 
-                                  <button
-                                    type="button"
-                                    onClick={() =>
-                                      removeIngredient(
-                                        "ungrouped",
-                                        ingredient.tempId
-                                      )
-                                    }
-                                    className={`btn btn-icon btn-icon-remove ${
-                                      isEditingTranslation
-                                        ? "translation-disabled"
-                                        : ""
-                                    }`}
-                                    aria-label={t("remove_ingredient")}
-                                    disabled={isEditingTranslation}
-                                  >
-                                    <Trash2
-                                      size={16}
-                                      data-testid="remove-ingredient-btn"
-                                    />
-                                  </button>
-                                </div>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    removeIngredient(
+                                      "ungrouped",
+                                      ingredient.tempId
+                                    )
+                                  }
+                                  className={`btn btn-icon btn-icon-remove ${
+                                    isEditingTranslation
+                                      ? "translation-disabled"
+                                      : ""
+                                  }`}
+                                  aria-label={t("remove_ingredient")}
+                                  disabled={isEditingTranslation}
+                                >
+                                  <Trash2
+                                    size={16}
+                                    data-testid="remove-ingredient-btn"
+                                  />
+                                </button>
                               </div>
                             </div>
                           </div>
@@ -740,78 +741,74 @@ const RecipeForm = ({
                                               </div>
 
                                               <div className="ingredient-content">
-                                                <div className=" input-with-icon-right ">
-                                                  {/* Ingredient Name */}
-                                                  <input
-                                                    id={`ingredient-name-${section.id}-${ingredientIndex}-${ingredient.tempId}`}
-                                                    type="text"
-                                                    value={
-                                                      ingredient.name || ""
-                                                    }
-                                                    onChange={(e) => {
-                                                      handleIngredientChange(
-                                                        section.id,
-                                                        ingredient.tempId,
-                                                        "name",
-                                                        e.target.value,
-                                                        validationErrors.ingredients
-                                                          ? "ingredients"
-                                                          : null
-                                                      );
-                                                    }}
-                                                    onKeyDown={(e) =>
-                                                      handleIngredientFieldEnter(
-                                                        e,
-                                                        "name",
-                                                        section.id,
-                                                        ingredient.tempId,
-                                                        ingredientIndex
-                                                      )
-                                                    }
-                                                    onBlur={(e) => {
-                                                      const value =
-                                                        i18n.language === "de"
-                                                          ? e.target.value
-                                                              .split(" ")
-                                                              .map(
-                                                                (word) =>
-                                                                  word
-                                                                    .charAt(0)
-                                                                    .toUpperCase() +
-                                                                  word
-                                                                    .slice(1)
-                                                                    .toLowerCase()
-                                                              )
-                                                              .join(" ")
-                                                          : e.target.value.toLowerCase();
-
-                                                      handleIngredientChange(
-                                                        section.id,
-                                                        ingredient.tempId,
-                                                        "name",
-                                                        value,
-                                                        validationErrors.ingredients
-                                                          ? "ingredients"
-                                                          : null
-                                                      );
-                                                    }}
-                                                    className={`input input--full-width input--edit ${
+                                                {/* Ingredient Name */}
+                                                <input
+                                                  id={`ingredient-name-${section.id}-${ingredientIndex}-${ingredient.tempId}`}
+                                                  type="text"
+                                                  value={ingredient.name || ""}
+                                                  onChange={(e) => {
+                                                    handleIngredientChange(
+                                                      section.id,
+                                                      ingredient.tempId,
+                                                      "name",
+                                                      e.target.value,
                                                       validationErrors.ingredients
-                                                        ? "input--error"
-                                                        : ""
-                                                    } ${
-                                                      getIngredientLink(
-                                                        section.id,
-                                                        ingredient.tempId
-                                                      )
-                                                        ? "ingredient-linked"
-                                                        : ""
-                                                    }`}
-                                                    placeholder={t(
-                                                      "ingredient_name"
-                                                    )}
-                                                  />
-                                                </div>
+                                                        ? "ingredients"
+                                                        : null
+                                                    );
+                                                  }}
+                                                  onKeyDown={(e) =>
+                                                    handleIngredientFieldEnter(
+                                                      e,
+                                                      "name",
+                                                      section.id,
+                                                      ingredient.tempId,
+                                                      ingredientIndex
+                                                    )
+                                                  }
+                                                  onBlur={(e) => {
+                                                    const value =
+                                                      i18n.language === "de"
+                                                        ? e.target.value
+                                                            .split(" ")
+                                                            .map(
+                                                              (word) =>
+                                                                word
+                                                                  .charAt(0)
+                                                                  .toUpperCase() +
+                                                                word
+                                                                  .slice(1)
+                                                                  .toLowerCase()
+                                                            )
+                                                            .join(" ")
+                                                        : e.target.value.toLowerCase();
+
+                                                    handleIngredientChange(
+                                                      section.id,
+                                                      ingredient.tempId,
+                                                      "name",
+                                                      value,
+                                                      validationErrors.ingredients
+                                                        ? "ingredients"
+                                                        : null
+                                                    );
+                                                  }}
+                                                  className={`input input--full-width input--edit ${
+                                                    validationErrors.ingredients
+                                                      ? "input--error"
+                                                      : ""
+                                                  } ${
+                                                    getIngredientLink(
+                                                      section.id,
+                                                      ingredient.tempId
+                                                    )
+                                                      ? "ingredient-linked"
+                                                      : ""
+                                                  }`}
+                                                  placeholder={t(
+                                                    "ingredient_name"
+                                                  )}
+                                                />
 
                                                 {/* Ingredient Details */}
                                                 <div className="ingredient-details">
@@ -921,100 +918,100 @@ const RecipeForm = ({
                                                     className="input input--full-width input--edit"
                                                     placeholder={t("notes")}
                                                   />
+                                                </div>
 
-                                                  <div className="flex-row">
-                                                    <button
-                                                      type="button"
-                                                      onClick={() => {
-                                                        const linkedRecipe =
-                                                          getIngredientLink(
-                                                            section.id,
-                                                            ingredient.tempId
-                                                          );
-                                                        if (linkedRecipe) {
-                                                          removeIngredientLink(
-                                                            section.id,
-                                                            ingredient.tempId
-                                                          );
-                                                        } else {
-                                                          handleOpenLinkDropdown(
-                                                            section.id,
-                                                            ingredient.tempId,
-                                                            ingredient
-                                                          );
-                                                        }
-                                                      }}
-                                                      className={`btn btn-icon ${
+                                                <div className="flex-row">
+                                                  <button
+                                                    type="button"
+                                                    onClick={() => {
+                                                      const linkedRecipe =
                                                         getIngredientLink(
                                                           section.id,
                                                           ingredient.tempId
-                                                        )
-                                                          ? "btn-icon-linked"
-                                                          : "btn-icon-link"
-                                                      } ${
-                                                        isEditingTranslation
-                                                          ? "translation-disabled"
-                                                          : ""
-                                                      }`}
-                                                      aria-label={
-                                                        getIngredientLink(
+                                                        );
+                                                      if (linkedRecipe) {
+                                                        removeIngredientLink(
                                                           section.id,
                                                           ingredient.tempId
-                                                        )
-                                                          ? "Remove link"
-                                                          : "Link to recipe"
-                                                      }
-                                                      disabled={
-                                                        isEditingTranslation
-                                                      }
-                                                      title={
-                                                        getIngredientLink(
+                                                        );
+                                                      } else {
+                                                        handleOpenLinkDropdown(
                                                           section.id,
-                                                          ingredient.tempId
-                                                        )
-                                                          ? `Linked to: ${
-                                                              getIngredientLink(
-                                                                section.id,
-                                                                ingredient.tempId
-                                                              ).title
-                                                            }`
-                                                          : "Link to recipe"
+                                                          ingredient.tempId,
+                                                          ingredient
+                                                        );
                                                       }
-                                                    >
-                                                      <Link
-                                                        size={16}
-                                                        className="link-default"
-                                                      />
-                                                      <X
-                                                        size={16}
-                                                        className="link-hover"
-                                                      />
-                                                    </button>
+                                                    }}
+                                                    className={`btn btn-icon ${
+                                                      getIngredientLink(
+                                                        section.id,
+                                                        ingredient.tempId
+                                                      )
+                                                        ? "btn-icon-linked"
+                                                        : "btn-icon-link"
+                                                    } ${
+                                                      isEditingTranslation
+                                                        ? "translation-disabled"
+                                                        : ""
+                                                    }`}
+                                                    aria-label={
+                                                      getIngredientLink(
+                                                        section.id,
+                                                        ingredient.tempId
+                                                      )
+                                                        ? "Remove link"
+                                                        : "Link to recipe"
+                                                    }
+                                                    disabled={
+                                                      isEditingTranslation
+                                                    }
+                                                    title={
+                                                      getIngredientLink(
+                                                        section.id,
+                                                        ingredient.tempId
+                                                      )
+                                                        ? `Linked to: ${
+                                                            getIngredientLink(
+                                                              section.id,
+                                                              ingredient.tempId
+                                                            ).title
+                                                          }`
+                                                        : "Link to recipe"
+                                                    }
+                                                  >
+                                                    <Link
+                                                      size={16}
+                                                      className="link-default"
+                                                    />
+                                                    <X
+                                                      size={16}
+                                                      className="link-hover"
+                                                    />
+                                                  </button>
 
-                                                    <button
-                                                      type="button"
-                                                      onClick={() =>
-                                                        removeIngredient(
-                                                          section.id,
-                                                          ingredient.tempId
-                                                        )
-                                                      }
-                                                      className={`btn btn-icon btn-icon-remove ${
-                                                        isEditingTranslation
-                                                          ? "translation-disabled"
-                                                          : ""
-                                                      }`}
-                                                      aria-label={t(
-                                                        "remove_ingredient"
-                                                      )}
-                                                      disabled={
-                                                        isEditingTranslation
-                                                      }
-                                                      data-testid={`remove-section-ingredient-btn-${section.id}-${ingredient.tempId}`} // Updated data-testid
-                                                    >
-                                                      <Trash2 size={16} />
-                                                    </button>
-                                                  </div>
+                                                  <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                      removeIngredient(
+                                                        section.id,
+                                                        ingredient.tempId
+                                                      )
+                                                    }
+                                                    className={`btn btn-icon btn-icon-remove ${
+                                                      isEditingTranslation
+                                                        ? "translation-disabled"
+                                                        : ""
+                                                    }`}
+                                                    aria-label={t(
+                                                      "remove_ingredient"
+                                                    )}
+                                                    disabled={
+                                                      isEditingTranslation
+                                                    }
+                                                    data-testid={`remove-section-ingredient-btn-${section.id}-${ingredient.tempId}`}
+                                                  >
+                                                    <Trash2 size={16} />
+                                                  </button>
                                                 </div>
                                               </div>
                                             </div>

--- a/src/components/RecipeForm/RecipeForm.jsx
+++ b/src/components/RecipeForm/RecipeForm.jsx
@@ -530,7 +530,7 @@ const RecipeForm = ({
                                       "ungrouped",
                                       ingredient.tempId
                                     )
-                                      ? "btn-icon-linked"
+                                      ? "btn-icon-link linked"
                                       : "btn-icon-link"
                                   } ${
                                     isEditingTranslation
@@ -933,7 +933,7 @@ const RecipeForm = ({
                                                         section.id,
                                                         ingredient.tempId
                                                       )
-                                                        ? "btn-icon-linked"
+                                                        ? "btn-icon-link linked"
                                                         : "btn-icon-link"
                                                     } ${
                                                       isEditingTranslation

--- a/src/components/RecipeForm/RecipeForm.jsx
+++ b/src/components/RecipeForm/RecipeForm.jsx
@@ -7,6 +7,7 @@ import {
   GripVertical,
   Link,
   NotepadText,
+  X,
 } from "lucide-react";
 import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
 
@@ -402,7 +403,6 @@ const RecipeForm = ({
                                     ? "input--error"
                                     : ""
                                 } ${
-                                  // TODO
                                   getIngredientLink(
                                     "ungrouped",
                                     ingredient.tempId
@@ -547,7 +547,7 @@ const RecipeForm = ({
                                         "ungrouped",
                                         ingredient.tempId
                                       )
-                                        ? "Remove recipe link"
+                                        ? "Remove link"
                                         : "Link to recipe"
                                     }
                                     disabled={isEditingTranslation}
@@ -556,7 +556,7 @@ const RecipeForm = ({
                                         "ungrouped",
                                         ingredient.tempId
                                       )
-                                        ? `Linked to: ${
+                                        ? `Linked to ${
                                             getIngredientLink(
                                               "ungrouped",
                                               ingredient.tempId
@@ -565,7 +565,8 @@ const RecipeForm = ({
                                         : "Link to recipe"
                                     }
                                   >
-                                    <Link size={16} />
+                                    <Link size={16} className="link-default" />
+                                    <X size={16} className="link-hover" />
                                   </button>
 
                                   <button
@@ -960,7 +961,7 @@ const RecipeForm = ({
                                                           section.id,
                                                           ingredient.tempId
                                                         )
-                                                          ? "Remove recipe link"
+                                                          ? "Remove link"
                                                           : "Link to recipe"
                                                       }
                                                       disabled={
@@ -980,7 +981,14 @@ const RecipeForm = ({
                                                           : "Link to recipe"
                                                       }
                                                     >
-                                                      <Link size={16} />
+                                                      <Link
+                                                        size={16}
+                                                        className="link-default"
+                                                      />
+                                                      <X
+                                                        size={16}
+                                                        className="link-hover"
+                                                      />
                                                     </button>
 
                                                     <button

--- a/src/components/RecipeForm/RecipeForm.jsx
+++ b/src/components/RecipeForm/RecipeForm.jsx
@@ -542,23 +542,10 @@ const RecipeForm = ({
                                       "ungrouped",
                                       ingredient.tempId
                                     )
-                                      ? "Remove link"
-                                      : "Link to recipe"
+                                      ? t("unlink_recipe")
+                                      : t("link_to_recipe")
                                   }
                                   disabled={isEditingTranslation}
-                                  title={
-                                    getIngredientLink(
-                                      "ungrouped",
-                                      ingredient.tempId
-                                    )
-                                      ? `Linked to ${
-                                          getIngredientLink(
-                                            "ungrouped",
-                                            ingredient.tempId
-                                          ).title
-                                        }`
-                                      : "Link to recipe"
-                                  }
                                 >
                                   <Link size={16} className="link-default" />
                                   <X size={16} className="link-hover" />
@@ -945,24 +932,11 @@ const RecipeForm = ({
                                                         section.id,
                                                         ingredient.tempId
                                                       )
-                                                        ? "Remove link"
-                                                        : "Link to recipe"
+                                                        ? t("unlink_recipe")
+                                                        : t("link_to_recipe")
                                                     }
                                                     disabled={
                                                       isEditingTranslation
-                                                    }
-                                                    title={
-                                                      getIngredientLink(
-                                                        section.id,
-                                                        ingredient.tempId
-                                                      )
-                                                        ? `Linked to: ${
-                                                            getIngredientLink(
-                                                              section.id,
-                                                              ingredient.tempId
-                                                            ).title
-                                                          }`
-                                                        : "Link to recipe"
                                                     }
                                                   >
                                                     <Link

--- a/src/components/RecipeLinkDropdown/RecipeLinkDropdown.css
+++ b/src/components/RecipeLinkDropdown/RecipeLinkDropdown.css
@@ -1,0 +1,115 @@
+.recipe-link-dropdown-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.recipe-link-dropdown {
+  background: var(--color-surface-primary);
+  border: var(--border-width) dashed var(--color-danger-dark);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 500px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.recipe-link-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border-bottom: var(--border-width) dashed var(--color-danger-dark);
+}
+
+.recipe-link-dropdown-header h3 {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--color-danger-dark);
+}
+
+.recipe-search-container {
+  padding: 0.75rem 1rem;
+  border-bottom: var(--border-width) dashed var(--color-danger-dark);
+}
+
+.search-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--color-text-light);
+  z-index: 1;
+}
+
+.recipe-search-input {
+  padding-left: 2.5rem !important;
+}
+
+.recipe-list-container {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  margin: 1rem;
+}
+
+.recipe-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 0.5rem;
+  border: none;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.recipe-item:hover {
+  color: var(--color-danger-dark);
+  font-weight: 500;
+  background-color: var(--color-background-hover);
+}
+
+.recipe-item:hover .recipe-title {
+  font-weight: 500;
+  color: var(--color-danger-dark);
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .recipe-link-dropdown-overlay {
+    padding: 0.5rem;
+    align-items: flex-start;
+    padding-top: 2rem;
+  }
+
+  .recipe-link-dropdown {
+    max-height: 85vh;
+    width: 100%;
+    max-width: none;
+  }
+
+  .recipe-link-dropdown-header {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .recipe-search-container {
+    padding: 0.5rem 0.75rem;
+  }
+}

--- a/src/components/RecipeLinkDropdown/RecipeLinkDropdown.css
+++ b/src/components/RecipeLinkDropdown/RecipeLinkDropdown.css
@@ -65,14 +65,15 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  margin: 1rem;
+  margin: 0.5rem 1rem;
+}
+
+.recipe-list-container:last-child {
+  margin-bottom: 0.75rem;
 }
 
 .recipe-item {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
   border: none;
   background: none;
   text-align: left;
@@ -80,15 +81,8 @@
   transition: all 0.15s ease;
 }
 
-.recipe-item:hover {
-  color: var(--color-danger-dark);
-  font-weight: 500;
-  background-color: var(--color-background-hover);
-}
-
-.recipe-item:hover .recipe-title {
-  font-weight: 500;
-  color: var(--color-danger-dark);
+.recipe-item .bold-small:hover {
+  color: var(--color-danger);
 }
 
 /* Mobile responsive */

--- a/src/components/RecipeLinkDropdown/RecipeLinkDropdown.jsx
+++ b/src/components/RecipeLinkDropdown/RecipeLinkDropdown.jsx
@@ -106,9 +106,7 @@ const RecipeLinkDropdown = ({
     <div className="recipe-link-dropdown-overlay">
       <div className="recipe-link-dropdown" ref={dropdownRef}>
         <div className="recipe-link-dropdown-header">
-          <h2 className="forta-red">
-            {t("link_to_recipe") || "Link to Recipe"}
-          </h2>
+          <h2 className="forta-red">{t("link_to_recipe")}</h2>
           <button
             type="button"
             onClick={onClose}
@@ -127,7 +125,7 @@ const RecipeLinkDropdown = ({
               type="text"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              placeholder={t("search_recipes") || "Search recipes..."}
+              placeholder={t("search_recipes")}
               className="input input--full-width recipe-search-input"
             />
           </div>

--- a/src/components/RecipeLinkDropdown/RecipeLinkDropdown.jsx
+++ b/src/components/RecipeLinkDropdown/RecipeLinkDropdown.jsx
@@ -1,0 +1,166 @@
+import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Search, X } from "lucide-react";
+import { fetchRecipes } from "../../services/recipes";
+import "./RecipeLinkDropdown.css";
+
+const RecipeLinkDropdown = ({
+  isOpen,
+  onClose,
+  onSelectRecipe,
+  currentRecipeId,
+}) => {
+  const { t } = useTranslation();
+  const [recipes, setRecipes] = useState([]);
+  const [filteredRecipes, setFilteredRecipes] = useState([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const searchInputRef = useRef(null);
+  const dropdownRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setLoading(true);
+      fetchRecipes()
+        .then((recipeList) => {
+          // Filter out current recipe to prevent self-linking
+          const filteredList = recipeList.filter(
+            (recipe) => recipe.id !== currentRecipeId
+          );
+          setRecipes(filteredList);
+          setFilteredRecipes(filteredList);
+        })
+        .catch((error) => {
+          console.error("Error fetching recipes:", error);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+
+      // Focus search input when dropdown opens
+      setTimeout(() => {
+        if (searchInputRef.current) {
+          searchInputRef.current.focus();
+        }
+      }, 100);
+    } else {
+      // Reset state when closed
+      setSearchTerm("");
+      setRecipes([]);
+      setFilteredRecipes([]);
+    }
+  }, [isOpen, currentRecipeId]);
+
+  useEffect(() => {
+    // Filter recipes based on search term
+    if (searchTerm.trim() === "") {
+      setFilteredRecipes(recipes);
+    } else {
+      const filtered = recipes.filter((recipe) =>
+        recipe.title.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+      setFilteredRecipes(filtered);
+    }
+  }, [searchTerm, recipes]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }
+  }, [isOpen, onClose]);
+
+  // Handle keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleRecipeSelect = (recipe) => {
+    onSelectRecipe(recipe);
+    onClose();
+  };
+
+  return (
+    <div className="recipe-link-dropdown-overlay">
+      <div className="recipe-link-dropdown" ref={dropdownRef}>
+        <div className="recipe-link-dropdown-header">
+          <h2 className="forta-red">
+            {t("link_to_recipe") || "Link to Recipe"}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-icon btn-icon-neutral btn-icon-right"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="recipe-search-container">
+          <div className="search-input-wrapper">
+            <Search size={16} className="search-icon" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder={t("search_recipes") || "Search recipes..."}
+              className="input input--full-width recipe-search-input"
+            />
+          </div>
+        </div>
+
+        <div className="recipe-list-container">
+          {loading ? (
+            <div className="recipe-loading">Loading recipes...</div>
+          ) : filteredRecipes.length === 0 ? (
+            <div>
+              {/* TODO - add to locale files - more in this file  */}
+              {searchTerm
+                ? "No recipes found matching your search."
+                : "No recipes available."}
+            </div>
+          ) : (
+            <div className="flex-column">
+              {filteredRecipes.map((recipe) => (
+                <button
+                  key={recipe.id}
+                  type="button"
+                  className="recipe-item"
+                  onClick={() => handleRecipeSelect(recipe)}
+                >
+                  <span className="bold-small">{recipe.title}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RecipeLinkDropdown;

--- a/src/pages/Recipe/Recipe.css
+++ b/src/pages/Recipe/Recipe.css
@@ -124,3 +124,37 @@
   z-index: var(--z-content);
   transition: opacity 0.3s ease-out;
 }
+
+/* Linked ingredients */
+.ingredient-name-linked {
+  color: var(--color-danger-dark);
+  text-decoration: underline;
+  text-decoration-color: var(--color-danger-dark);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  transition: color 0.2s ease;
+}
+
+.ingredient-name-linked:hover {
+  color: var(--color-danger);
+}
+
+.link-icon {
+  flex-shrink: 0;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .ingredient-name-linked {
+    gap: 0.125rem;
+  }
+
+  .link-icon {
+    width: 10px;
+    height: 10px;
+  }
+}

--- a/src/pages/Recipe/Recipe.jsx
+++ b/src/pages/Recipe/Recipe.jsx
@@ -2,7 +2,7 @@ import "./Recipe.css";
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Pencil, ShoppingBasket, Loader2, Share2 } from "lucide-react";
+import { Pencil, ShoppingBasket, Loader2, Share2, ExternalLink } from "lucide-react";
 
 import { useRecipe } from "../../hooks/data/useRecipe";
 import { fetchSharedRecipe } from "../../services/sharingService";
@@ -102,35 +102,58 @@ const Recipe = ({ isSharedView = false }) => {
     return allIngredients;
   };
 
+  // Helper function to get linked recipe for an ingredient
+  const getLinkedRecipe = (ingredient, keyPrefix, index) => {
+    const linkKey = `${keyPrefix}-${ingredient.id || ingredient.recipe_ingredient_id || index}`;
+    return recipe.ingredientLinks?.[linkKey];
+  };
+
   // Helper to render an ingredient item
-  const renderIngredientItem = (ingredient, keyPrefix, index) => (
-    <li key={`${keyPrefix}-${index}-${ingredient.id}`} className="ingredient">
-      <input
-        type="checkbox"
-        checked={checkedIngredients[ingredient.recipe_ingredient_id] || false}
-        onChange={() => handleCheckboxChange(ingredient.recipe_ingredient_id)}
-        id={`ingredient-${keyPrefix}-${index}-${ingredient.id}`}
-      />
-      <label htmlFor={`ingredient-${keyPrefix}-${index}-${ingredient.id}`}>
-        <span className="ingredient-measurement">
+  const renderIngredientItem = (ingredient, keyPrefix, index) => {
+    const linkedRecipe = getLinkedRecipe(ingredient, keyPrefix, index);
+    
+    return (
+      <li key={`${keyPrefix}-${index}-${ingredient.id}`} className="ingredient">
+        <input
+          type="checkbox"
+          checked={checkedIngredients[ingredient.recipe_ingredient_id] || false}
+          onChange={() => handleCheckboxChange(ingredient.recipe_ingredient_id)}
+          id={`ingredient-${keyPrefix}-${index}-${ingredient.id}`}
+        />
+        <label htmlFor={`ingredient-${keyPrefix}-${index}-${ingredient.id}`}>
+          <span className="ingredient-measurement">
+            {formatIngredientMeasurement(
+              ingredient.quantity,
+              ingredient.unit,
+              t("units", { returnObjects: true })
+            )}
+          </span>
           {formatIngredientMeasurement(
             ingredient.quantity,
             ingredient.unit,
             t("units", { returnObjects: true })
+          ) && " "}
+          
+          {linkedRecipe ? (
+            <span 
+              className="ingredient-name-linked"
+              onClick={() => navigate(`/${linkedRecipe.id}/${linkedRecipe.slug || linkedRecipe.title.toLowerCase().replace(/\s+/g, '-')}`)}
+              title={`Go to ${linkedRecipe.title}`}
+            >
+              {getIngredientDisplayName(ingredient, i18n.language)}
+              <ExternalLink size={12} className="link-icon" />
+            </span>
+          ) : (
+            getIngredientDisplayName(ingredient, i18n.language)
           )}
-        </span>
-        {formatIngredientMeasurement(
-          ingredient.quantity,
-          ingredient.unit,
-          t("units", { returnObjects: true })
-        ) && " "}
-        {getIngredientDisplayName(ingredient, i18n.language)}
-        {ingredient.notes && (
-          <span className="ingredient-notes"> {ingredient.notes}</span>
-        )}
-      </label>
-    </li>
-  );
+          
+          {ingredient.notes && (
+            <span className="ingredient-notes"> {ingredient.notes}</span>
+          )}
+        </label>
+      </li>
+    );
+  };
 
   if (loading) {
     return <LoadingAcorn />;

--- a/src/pages/Recipe/Recipe.jsx
+++ b/src/pages/Recipe/Recipe.jsx
@@ -130,7 +130,6 @@ const Recipe = ({ isSharedView = false }) => {
             <a
               className="ingredient-name-linked"
               href={`/${ingredient.linked_recipe.id}/${ingredient.linked_recipe.slug}`}
-              title={`Go to ${ingredient.linked_recipe.title}`}
               onClick={(e) => e.stopPropagation()}
             >
               {getIngredientDisplayName(ingredient, i18n.language)}

--- a/src/pages/Recipe/Recipe.jsx
+++ b/src/pages/Recipe/Recipe.jsx
@@ -2,7 +2,7 @@ import "./Recipe.css";
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Pencil, ShoppingBasket, Loader2, Share2, ExternalLink } from "lucide-react";
+import { Pencil, ShoppingBasket, Loader2, Share2 } from "lucide-react";
 
 import { useRecipe } from "../../hooks/data/useRecipe";
 import { fetchSharedRecipe } from "../../services/sharingService";
@@ -102,16 +102,8 @@ const Recipe = ({ isSharedView = false }) => {
     return allIngredients;
   };
 
-  // Helper function to get linked recipe for an ingredient
-  const getLinkedRecipe = (ingredient, keyPrefix, index) => {
-    const linkKey = `${keyPrefix}-${ingredient.id || ingredient.recipe_ingredient_id || index}`;
-    return recipe.ingredientLinks?.[linkKey];
-  };
-
   // Helper to render an ingredient item
   const renderIngredientItem = (ingredient, keyPrefix, index) => {
-    const linkedRecipe = getLinkedRecipe(ingredient, keyPrefix, index);
-    
     return (
       <li key={`${keyPrefix}-${index}-${ingredient.id}`} className="ingredient">
         <input
@@ -133,20 +125,20 @@ const Recipe = ({ isSharedView = false }) => {
             ingredient.unit,
             t("units", { returnObjects: true })
           ) && " "}
-          
-          {linkedRecipe ? (
-            <span 
+
+          {ingredient.linked_recipe ? (
+            <a
               className="ingredient-name-linked"
-              onClick={() => navigate(`/${linkedRecipe.id}/${linkedRecipe.slug || linkedRecipe.title.toLowerCase().replace(/\s+/g, '-')}`)}
-              title={`Go to ${linkedRecipe.title}`}
+              href={`/${ingredient.linked_recipe.id}/${ingredient.linked_recipe.slug}`}
+              title={`Go to ${ingredient.linked_recipe.title}`}
+              onClick={(e) => e.stopPropagation()}
             >
               {getIngredientDisplayName(ingredient, i18n.language)}
-              <ExternalLink size={12} className="link-icon" />
-            </span>
+            </a>
           ) : (
             getIngredientDisplayName(ingredient, i18n.language)
           )}
-          
+
           {ingredient.notes && (
             <span className="ingredient-notes"> {ingredient.notes}</span>
           )}

--- a/src/pages/Recipe/Recipe.jsx
+++ b/src/pages/Recipe/Recipe.jsx
@@ -48,7 +48,7 @@ const Recipe = ({ isSharedView = false }) => {
           );
           setSharedRecipe(translatedRecipe);
         } catch (err) {
-          setSharedError(err.message || "Failed to load shared recipe");
+          setSharedError(err.message || t("failed_load_shared_recipe"));
         } finally {
           setSharedLoading(false);
         }
@@ -56,7 +56,7 @@ const Recipe = ({ isSharedView = false }) => {
 
       loadSharedRecipe();
     }
-  }, [isSharedView, shareToken, i18n.language]);
+  }, [isSharedView, shareToken, i18n.language, t]);
 
   // Determine which recipe and state to use
   const recipe = isSharedView ? sharedRecipe : ownedRecipe;

--- a/src/pages/Settings/CategoriesTab.jsx
+++ b/src/pages/Settings/CategoriesTab.jsx
@@ -570,7 +570,7 @@ const CategoriesTab = ({
                             />
                           ) : (
                             <>
-                              <span className="category-name">
+                              <span className="bold-small">
                                 {category.label}
                               </span>
                               {category.isSystem && (

--- a/src/pages/Settings/Settings.css
+++ b/src/pages/Settings/Settings.css
@@ -178,11 +178,6 @@
   gap: 0.5rem;
 }
 
-.category-name {
-  font-weight: 500;
-  color: var(--color-text-strong);
-}
-
 .category-system-badge {
   background-color: var(--color-border-light);
   color: var(--color-text-primary);
@@ -256,10 +251,6 @@
   .tab-button {
     flex: 1;
     text-align: center;
-  }
-
-  .category-name {
-    font-size: 0.9rem;
   }
 
   /* On mobile, only wrap edit actions to new line */

--- a/src/services/recipes.js
+++ b/src/services/recipes.js
@@ -530,7 +530,7 @@ export const fetchRecipe = async (id) => {
     .from("recipes")
     .select(
       `*, 
-       recipe_ingredients(id, quantity, unit, ingredients(id, singular_name, plural_name, translated_names), notes, subheading, order_index, is_plural, name_overrides),
+       recipe_ingredients!recipe_ingredients_recipe_id_fkey(id, quantity, unit, ingredients(id, singular_name, plural_name, translated_names), notes, subheading, order_index, is_plural, name_overrides, linked_recipe_id, linked_recipe:recipes!linked_recipe_id(id, title)),
        recipe_categories(categoriy_id, categories(name, translated_category))`
     )
     .eq("id", id)
@@ -558,6 +558,8 @@ export const fetchRecipe = async (id) => {
           subheading: item.subheading,
           order_index: item.order_index,
           is_plural: item.is_plural,
+          linked_recipe_id: item.linked_recipe_id,
+          linked_recipe: item.linked_recipe,
         };
       }) || [];
 
@@ -796,6 +798,10 @@ export const createRecipe = async (
         throw new Error("Ingredient must have either ingredient_id or name");
       }
 
+      // Check for linked recipe
+      const linkKey = `ungrouped-${ingredient.tempId}`;
+      const linkedRecipe = recipeData.ingredientLinks?.[linkKey];
+
       recipeIngredientsToInsert.push({
         recipe_id: recipe.id,
         ingredient_id: ingredientId,
@@ -805,6 +811,7 @@ export const createRecipe = async (
         subheading: null, // Ungrouped ingredients have no subheading
         order_index: globalOrderIndex++,
         is_plural: isPlural,
+        linked_recipe_id: linkedRecipe?.id || null,
       });
     }
   }
@@ -836,6 +843,10 @@ export const createRecipe = async (
           throw new Error("Ingredient must have either ingredient_id or name");
         }
 
+        // Check for linked recipe
+        const linkKey = `${section.id}-${ingredient.tempId}`;
+        const linkedRecipe = recipeData.ingredientLinks?.[linkKey];
+
         recipeIngredientsToInsert.push({
           recipe_id: recipe.id,
           ingredient_id: ingredientId,
@@ -845,6 +856,7 @@ export const createRecipe = async (
           subheading: section.subheading || null,
           order_index: globalOrderIndex++,
           is_plural: isPlural,
+          linked_recipe_id: linkedRecipe?.id || null,
         });
       }
     }
@@ -881,6 +893,11 @@ export const createRecipe = async (
         throw new Error("Ingredient must have either ingredient_id or name");
       }
 
+      // Check for linked recipe (fallback structure)
+      const sectionId = ingredient.subheading ? `section-${i}` : "ungrouped";
+      const linkKey = `${sectionId}-${ingredient.tempId}`;
+      const linkedRecipe = recipeData.ingredientLinks?.[linkKey];
+
       recipeIngredientsToInsert.push({
         recipe_id: recipe.id,
         ingredient_id: ingredientId,
@@ -890,6 +907,7 @@ export const createRecipe = async (
         subheading: ingredient.subheading || null,
         order_index: i,
         is_plural: isPlural,
+        linked_recipe_id: linkedRecipe?.id || null,
       });
     }
   }
@@ -1046,6 +1064,10 @@ export const updateRecipe = async (
         existingRecipe?.original_language || "en"
       );
 
+      // Check for linked recipe
+      const linkKey = `ungrouped-${ingredient.tempId}`;
+      const linkedRecipe = recipeData.ingredientLinks?.[linkKey];
+
       recipeIngredientsToInsert.push({
         recipe_id: id,
         ingredient_id: ingredientId,
@@ -1055,6 +1077,7 @@ export const updateRecipe = async (
         subheading: null, // Ungrouped ingredients have no subheading
         order_index: globalOrderIndex++,
         is_plural: isPlural,
+        linked_recipe_id: linkedRecipe?.id || null,
       });
     }
   }
@@ -1102,6 +1125,10 @@ export const updateRecipe = async (
           existingRecipe?.original_language || "en"
         );
 
+        // Check for linked recipe
+        const linkKey = `${section.id}-${ingredient.tempId}`;
+        const linkedRecipe = recipeData.ingredientLinks?.[linkKey];
+
         recipeIngredientsToInsert.push({
           recipe_id: id,
           ingredient_id: ingredientId,
@@ -1111,6 +1138,7 @@ export const updateRecipe = async (
           subheading: section.subheading || null,
           order_index: globalOrderIndex++,
           is_plural: isPlural,
+          linked_recipe_id: linkedRecipe?.id || null,
         });
       }
     }
@@ -1161,6 +1189,11 @@ export const updateRecipe = async (
         existingRecipe?.original_language || "en"
       );
 
+      // Check for linked recipe (fallback structure)
+      const sectionId = ingredient.subheading ? `section-${i}` : "ungrouped";
+      const linkKey = `${sectionId}-${ingredient.tempId}`;
+      const linkedRecipe = recipeData.ingredientLinks?.[linkKey];
+
       recipeIngredientsToInsert.push({
         recipe_id: id,
         ingredient_id: ingredientId,
@@ -1170,6 +1203,7 @@ export const updateRecipe = async (
         subheading: ingredient.subheading || null,
         order_index: i,
         is_plural: isPlural,
+        linked_recipe_id: linkedRecipe?.id || null,
       });
     }
   }

--- a/src/services/recipes.js
+++ b/src/services/recipes.js
@@ -530,7 +530,7 @@ export const fetchRecipe = async (id) => {
     .from("recipes")
     .select(
       `*, 
-       recipe_ingredients!recipe_ingredients_recipe_id_fkey(id, quantity, unit, ingredients(id, singular_name, plural_name, translated_names), notes, subheading, order_index, is_plural, name_overrides, linked_recipe_id, linked_recipe:recipes!linked_recipe_id(id, title)),
+       recipe_ingredients!recipe_ingredients_recipe_id_fkey(id, quantity, unit, ingredients(id, singular_name, plural_name, translated_names), notes, subheading, order_index, is_plural, name_overrides, linked_recipe_id, linked_recipe:recipes!linked_recipe_id(id, title, slug)),
        recipe_categories(categoriy_id, categories(name, translated_category))`
     )
     .eq("id", id)

--- a/src/styles/components/inputs.css
+++ b/src/styles/components/inputs.css
@@ -117,17 +117,6 @@
   padding-right: 2.5rem;
 }
 
-/* Spacing to the right for ingredient link */
-.input-with-icon-right {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.input-with-icon-right input {
-  padding-right: 2.5rem;
-}
-
 /* Fix eye icon positioning - override the general svg rule */
 .input-with-icon .btn-icon-right svg {
   position: static;

--- a/src/styles/components/inputs.css
+++ b/src/styles/components/inputs.css
@@ -117,6 +117,17 @@
   padding-right: 2.5rem;
 }
 
+/* Spacing to the right for ingredient link */
+.input-with-icon-right {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-with-icon-right input {
+  padding-right: 2.5rem;
+}
+
 /* Fix eye icon positioning - override the general svg rule */
 .input-with-icon .btn-icon-right svg {
   position: static;

--- a/src/styles/globals/typography.css
+++ b/src/styles/globals/typography.css
@@ -55,7 +55,6 @@ h3 {
 h1.forta-red {
   font-family: var(--font-forta);
   color: var(--color-danger-dark);
-  /* TODO - maybe remove below line? */
   line-height: 1;
 }
 

--- a/src/styles/globals/typography.css
+++ b/src/styles/globals/typography.css
@@ -74,6 +74,12 @@ h2.forta {
   font-size: 1rem;
 }
 
+h2.forta-red {
+  font-family: var(--font-forta);
+  color: var(--color-danger-dark);
+  font-size: 1rem;
+}
+
 h2.forta-small {
   font-family: var(--font-forta);
   font-size: 0.9rem;
@@ -121,8 +127,18 @@ h3.forta {
   line-height: 1;
 }
 
+.bold-small {
+  font-weight: bold;
+  color: var(--color-text-strong);
+  font-size: 1rem;
+}
+
 @media (max-width: 768px) {
   h1 {
     font-size: 1.5rem;
+  }
+
+  .bold-small {
+    font-size: 0.9rem;
   }
 }

--- a/src/styles/globals/typography.css
+++ b/src/styles/globals/typography.css
@@ -128,7 +128,7 @@ h3.forta {
 }
 
 .bold-small {
-  font-weight: bold;
+  font-weight: 600;
   color: var(--color-text-strong);
   font-size: 1rem;
 }


### PR DESCRIPTION
- Allow users to link ingredients in a recipe to other recipes
- Add a modal dropdown for searching and selecting recipes to link on RecipeForm page
- Clicking on an ingredient link from Recipe page redirects to the linked recipe
- Add unit tests for new ingredient-recipe linking functionality 

<img width="200" alt="localhost_5173_edit-recipe_48_tofu(iPhone 12 Pro) (2)" src="https://github.com/user-attachments/assets/3e125945-5516-453d-9da7-a5d1c9d62e72" />
<img width="200" alt="localhost_5173_edit-recipe_48_tofu(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/29228ee1-256a-4339-9093-a7ca3431dc3c" />
<img width="200" alt="localhost_5173_48_tofu(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/b6dc448c-a0f7-47f0-9992-21bb73e4972b" />